### PR TITLE
Update close-modal.md

### DIFF
--- a/docs/close-modal.md
+++ b/docs/close-modal.md
@@ -48,6 +48,24 @@ function closeModal() {
 </template>
 ```
 
+```vue [Vue 3.5+]
+<script setup>
+import { useTemplateRef } from 'vue';
+
+const modalRef = useTemplateRef('modalRef');
+
+function closeModal() {
+    modalRef.value.close();
+}
+</script>
+
+<template>
+    <Modal ref="modalRef">
+        <!-- ... -->
+    </Modal>
+</template>
+```
+
 ```jsx [React]
 import { useRef } from 'react';
 


### PR DESCRIPTION
In Vue 3.5+ the ways refs work have been significantly changed and the older method no longer works.

https://vuejs.org/guide/essentials/template-refs.html#accessing-the-refs