### PR TITLE
Fixes react programmatic usage example

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -335,8 +335,10 @@ function createUserModal() {
 import { useModalStack } from '@inertiaui/modal-react'
 
 function UserIndex() {
+    const modalStack = useModalStack();
+
     function createUserModal() {
-        useModalStack().visitModal('/users/create')
+        modalStack.visitModal('/users/create')
     }
 
     return (


### PR DESCRIPTION
Minor fixes in the React example for programmatic usage. Before the fix, I encountered the following error:

```
Uncaught Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem.
    at TaskCard.jsxDEV.onClick (TaskCard.jsx:67:11)
```