### PR TITLE
Export useModalStack

### DIFF
--- a/vue/src/inertiauiModal.js
+++ b/vue/src/inertiauiModal.js
@@ -50,5 +50,6 @@ export {
     renderApp,
     resetConfig,
     useModal,
+    useModalStack,
     visitModal,
 }


### PR DESCRIPTION
Closes #135. Adds `useModalStack` to the list of exports in `vue/src/inertiauiModal.js`, allowing other modules to import and use this function.