### PR TITLE
Add whereModal and whereBaseRouteUrl helpers

### DIFF
--- a/src/ModalServiceProvider.php
+++ b/src/ModalServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Inertia\Response;
 use Inertia\ResponseFactory;
+use Inertia\Testing\AssertableInertia;
 use Tighten\Ziggy\BladeRouteGenerator;
 
 class ModalServiceProvider extends ServiceProvider
@@ -91,6 +92,8 @@ class ModalServiceProvider extends ServiceProvider
             // ensuring that modal-specific redirects (like closing a modal) work correctly.
             $this->app->alias('inertiaui_modal_redirector', 'redirect');
         }
+
+        $this->registerTestingMacros();
     }
 
     /**
@@ -99,5 +102,20 @@ class ModalServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/inertiaui-modal.php', 'inertiaui-modal');
+    }
+
+    private function registerTestingMacros(): void
+    {
+        AssertableInertia::macro('whereModal', function (string $expected) {
+            $this->where('_inertiaui_modal.component', $expected);
+
+            return $this;
+        });
+
+        AssertableInertia::macro('whereBaseRouteUrl', function (string $expected) {
+            $this->where('_inertiaui_modal.baseUrl', $expected);
+
+            return $this;
+        });
     }
 }


### PR DESCRIPTION
Hello!

I've added a few macros that help with testing on the \Inertia\Testing\AssertableInertia class.

Here's some examples of how the can be used.

Before:
```php 
it('uses the correct modal', function () {
    $user = User::factory()->create();

    $this->actingAs($user)
        ->get(route('customers.create'))
        ->assertInertia(fn (AssertableInertia $page) => $page
            ->where('_inertiaui_modal.component', 'Customers/Create')
        );
});

it('uses the correct base route', function () {
    $user = User::factory()->create();

    $this->actingAs($user)
        ->get(route('customers.create'))
        ->assertInertia(fn (AssertableInertia $page) => $page
            ->where('_inertiaui_modal.baseUrl', route('customers.index'))
        );
});
```

After:

```php
it('uses the correct modal', function () {
    $user = User::factory()->create();

    $this->actingAs($user)
        ->get(route('customers.create'))
        ->assertInertia(fn (AssertableInertia $page) => $page->whereModal('Customers/Create'));
});

it('uses the correct base route', function () {
    $user = User::factory()->create();

    $this->actingAs($user)
        ->get(route('customers.create'))
        ->assertInertia(fn (AssertableInertia $page) => $page
            ->whereBaseRouteUrl(route('customers.index'))
        );
});
```

