### PR TITLE
Add InertiaJS v3 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: true
       matrix:
         laravel: ['11.0', '12.0', '13.0']
-        inertia: [v1, v2]
+        inertia: [v1, v2, v3]
         stack: [react-18, react-19, vue]
         app_mounting: [auto, custom]
         exclude:
@@ -40,6 +40,8 @@ jobs:
             laravel: 13.0
           - inertia: v1
             laravel: 12.0
+          - inertia: v3
+            stack: react-18
           - laravel: 12.0
             stack: react-18
           - laravel: 12.0
@@ -131,7 +133,7 @@ jobs:
           if [ "${{ matrix.laravel }}" == "13.0" ]; then
             composer remove laravel/tinker --no-update
           fi
-          composer require laravel/framework:^${{ matrix.laravel }} inertiajs/inertia-laravel:${{ matrix.inertia == 'v1' && '^1.3' || '^2.0' }}
+          composer require laravel/framework:^${{ matrix.laravel }} inertiajs/inertia-laravel:${{ matrix.inertia == 'v1' && '^1.3' || (matrix.inertia == 'v2' && '^2.0' || '^3.0') }}
           composer install --no-progress --prefer-dist --optimize-autoloader
           php artisan about
           npm ci
@@ -141,7 +143,7 @@ jobs:
             npm install react@^19.0.0 react-dom@^19.0.0
           fi
           npm list react react-dom vue
-          npm install @inertiajs/react@${{ matrix.inertia == 'v1' && '1.3.0' || '2.0.0' }} @inertiajs/vue3@${{ matrix.inertia == 'v1' && '1.3.0' || '2.0.0' }}
+          npm install @inertiajs/react@${{ matrix.inertia == 'v1' && '1.3.0' || (matrix.inertia == 'v2' && '2.0.0' || '3.0.0-beta.3') }} @inertiajs/vue3@${{ matrix.inertia == 'v1' && '1.3.0' || (matrix.inertia == 'v2' && '2.0.0' || '3.0.0-beta.3') }}
           npm install --install-links ../react
           npm install --install-links ../vue
           test -d node_modules/@inertiaui/modal-react || exit 1

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/contracts": "^10.48||^11.11||^12.0",
-        "inertiajs/inertia-laravel": "^1.3|^2.0"
+        "inertiajs/inertia-laravel": "^1.3|^2.0|^3.0"
     },
     "require-dev": {
         "larastan/larastan": "^2.9",

--- a/demo-app/composer.json
+++ b/demo-app/composer.json
@@ -19,7 +19,7 @@
         "laravel/pint": "^1.0",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^8.0",
-        "phpunit/phpunit": "^11.5.2"
+        "phpunit/phpunit": "^11.5.2||^12.5"
     },
     "repositories": [
         {

--- a/demo-app/routes/web.php
+++ b/demo-app/routes/web.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 use Inertia\Inertia;
 use InertiaUI\Modal\Support;
 
-$deferred = fn (string $data) => Support::isInertiaV2()
+$deferred = fn (string $data) => ! Support::isInertiaV1()
     ? Inertia::defer(fn () => request()->header('X-InertiaUI-Modal-Base-Url')
         ? 'Deferred data with Base URL header: '.$data
         : 'Deferred data without Base URL header: '.$data
@@ -37,17 +37,17 @@ Route::get('/modal-events', function (User $user) {
 
 // Modal Props
 Route::get('/modal-props-ignore-first-load', function () {
-    $inertiaV2 = Support::isInertiaV2();
+    $supportsDefer = ! Support::isInertiaV1();
 
-    $defer = fn (int $delay, string $data, string $group) => $inertiaV2
+    $defer = fn (int $delay, string $data, string $group) => $supportsDefer
         ? Inertia::defer(function () use ($delay, $data) {
             usleep($delay * 1000);
 
             return $data;
         }, $group) : $data;
 
-    $optional = fn (int $delay, string $data) => $inertiaV2
-        ? Inertia::lazy(function () use ($delay, $data) {
+    $optional = fn (int $delay, string $data) => $supportsDefer
+        ? Inertia::optional(function () use ($delay, $data) {
             usleep($delay * 1000);
 
             return $data;
@@ -57,7 +57,7 @@ Route::get('/modal-props-ignore-first-load', function () {
         'deferA' => $defer(250, 'Deferred data A- '.Str::random(), 'group-a'),
         'deferB' => $defer(500, 'Deferred data B- '.Str::random(), 'group-b'),
         'optional' => $optional(500, 'Optional data - '.Str::random()),
-        'lazy' => Inertia::lazy(function () {
+        'lazy' => (Support::isInertiaV1() ? Inertia::lazy(...) : Inertia::optional(...))(function () {
             usleep(500 * 1000);
 
             return 'Lazy data - '.Str::random();

--- a/react/package.json
+++ b/react/package.json
@@ -27,7 +27,7 @@
     "devDependencies": {
         "@headlessui/react": "^2.1.0",
         "@heroicons/react": "^2.1.4",
-        "@inertiajs/react": "^1.3.0||^2.1.11",
+        "@inertiajs/react": "^1.3.0||^2.1.11||^3.0.0-beta",
         "@vitejs/plugin-react": "^4.3.1",
         "axios": "^1.6.0",
         "clsx": "^2.1.1",
@@ -46,7 +46,7 @@
         "vite": "^6.1"
     },
     "peerDependencies": {
-        "@inertiajs/react": "^1.3.0||^2.1.11",
+        "@inertiajs/react": "^1.3.0||^2.1.11||^3.0.0-beta",
         "axios": "^1.6.0",
         "react": "^18.2.0||^19.0.0",
         "react-dom": "^18.2.0||^19.0.0"

--- a/react/src/ModalRoot.jsx
+++ b/react/src/ModalRoot.jsx
@@ -576,6 +576,7 @@ export const ModalRoot = ({ children }) => {
                             return
                         }
                         if (!isNavigating && typeof window !== 'undefined' && window.location.href !== modalOnBase.baseUrl) {
+                            baseUrl = null
                             router.visit(modalOnBase.baseUrl, {
                                 preserveScroll: true,
                                 preserveState: true,
@@ -592,7 +593,7 @@ export const ModalRoot = ({ children }) => {
         // so it can redirect back with the back() helper method...
         const baseUrlHeader = baseUrl ?? (initialModalStillOpened ? $page.props._inertiaui_modal?.baseUrl : null)
 
-        if (config.headers) {
+        if (config.headers && baseUrlHeader) {
             config.headers['X-InertiaUI-Modal-Base-Url'] = baseUrlHeader
         }
 

--- a/react/src/ModalRoot.jsx
+++ b/react/src/ModalRoot.jsx
@@ -577,6 +577,7 @@ export const ModalRoot = ({ children }) => {
                         }
                         if (!isNavigating && typeof window !== 'undefined' && window.location.href !== modalOnBase.baseUrl) {
                             baseUrl = null
+                            initialModalStillOpened = false
                             router.visit(modalOnBase.baseUrl, {
                                 preserveScroll: true,
                                 preserveState: true,

--- a/react/src/ModalRoot.jsx
+++ b/react/src/ModalRoot.jsx
@@ -587,17 +587,26 @@ export const ModalRoot = ({ children }) => {
         [],
     )
 
-    const axiosRequestInterceptor = (config) => {
+    const requestInterceptor = (config) => {
         // A Modal is opened on top of a base route, so we need to pass this base route
         // so it can redirect back with the back() helper method...
-        config.headers['X-InertiaUI-Modal-Base-Url'] = baseUrl ?? (initialModalStillOpened ? $page.props._inertiaui_modal?.baseUrl : null)
+        const baseUrlHeader = baseUrl ?? (initialModalStillOpened ? $page.props._inertiaui_modal?.baseUrl : null)
+
+        if (config.headers) {
+            config.headers['X-InertiaUI-Modal-Base-Url'] = baseUrlHeader
+        }
 
         return config
     }
 
     useEffect(() => {
-        Axios.interceptors.request.use(axiosRequestInterceptor)
-        return () => Axios.interceptors.request.eject(axiosRequestInterceptor)
+        const http = InertiaReact.http && typeof InertiaReact.http.onRequest === 'function' ? InertiaReact.http : null
+        const removeHttpInterceptor = http ? http.onRequest(requestInterceptor) : null
+        Axios.interceptors.request.use(requestInterceptor)
+        return () => {
+            removeHttpInterceptor?.()
+            Axios.interceptors.request.eject(requestInterceptor)
+        }
     }, [])
 
     const previousModalRef = useRef()

--- a/scripts/use-inertia-1.sh
+++ b/scripts/use-inertia-1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+cd demo-app
+composer require inertiajs/inertia-laravel:^1.3 -W --no-interaction
+npm install @inertiajs/react@1.3.0 @inertiajs/vue3@1.3.0

--- a/scripts/use-inertia-2.sh
+++ b/scripts/use-inertia-2.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+cd demo-app
+composer require inertiajs/inertia-laravel:^2.0 -W --no-interaction
+npm install @inertiajs/react@2.0.0 @inertiajs/vue3@2.0.0

--- a/scripts/use-inertia-3.sh
+++ b/scripts/use-inertia-3.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+cd demo-app
+composer require inertiajs/inertia-laravel:^3.0 -W --no-interaction
+npm install @inertiajs/react@3.0.0-beta.3 @inertiajs/vue3@3.0.0-beta.3

--- a/src/DispatchBaseUrlRequest.php
+++ b/src/DispatchBaseUrlRequest.php
@@ -37,15 +37,10 @@ class DispatchBaseUrlRequest
         $requestForBaseUrl->setRequestLocale($originalRequest->getLocale());
         $requestForBaseUrl->setDefaultRequestLocale($originalRequest->getDefaultLocale());
 
-        // Copy the session from the original request so that middleware
-        // that runs before StartSession can access it without errors.
-        if ($originalRequest->hasSession()) {
-            $requestForBaseUrl->setLaravelSession($originalRequest->session());
-        }
-
         $route = $this->router->getRoutes()->match($requestForBaseUrl);
         $requestForBaseUrl->setRouteResolver(fn () => $route);
 
+        // No need to call setLaravelSession() as it's done by the StartSession middleware
         // No need to call setUserResolver() as it's done by AuthServiceProvider::registerRequestRebindHandler()
 
         // Dispatch the request without encrypting cookies because that has

--- a/src/DispatchBaseUrlRequest.php
+++ b/src/DispatchBaseUrlRequest.php
@@ -37,10 +37,15 @@ class DispatchBaseUrlRequest
         $requestForBaseUrl->setRequestLocale($originalRequest->getLocale());
         $requestForBaseUrl->setDefaultRequestLocale($originalRequest->getDefaultLocale());
 
+        // Copy the session from the original request so that middleware
+        // that runs before StartSession can access it without errors.
+        if ($originalRequest->hasSession()) {
+            $requestForBaseUrl->setLaravelSession($originalRequest->session());
+        }
+
         $route = $this->router->getRoutes()->match($requestForBaseUrl);
         $requestForBaseUrl->setRouteResolver(fn () => $route);
 
-        // No need to call setLaravelSession() as it's done by the StartSession middleware
         // No need to call setUserResolver() as it's done by AuthServiceProvider::registerRequestRebindHandler()
 
         // Dispatch the request without encrypting cookies because that has

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -171,7 +171,15 @@ class Modal implements Responsable
         $data = $response->getData(true);
         $data['meta'] = [];
 
-        foreach (['mergeProps', 'deferredProps', 'cache'] as $key) {
+        // Inertia v2 keys: mergeProps, deferredProps, cache
+        // Inertia v3 keys: mergeProps, prependProps, deepMergeProps, matchPropsOn, deferredProps, scrollProps, onceProps, sharedProps
+        $metaKeys = [
+            'mergeProps', 'deferredProps', 'cache',
+            'prependProps', 'deepMergeProps', 'matchPropsOn',
+            'scrollProps', 'onceProps', 'sharedProps',
+        ];
+
+        foreach ($metaKeys as $key) {
             if (! array_key_exists($key, $data)) {
                 continue;
             }

--- a/src/ModalServiceProvider.php
+++ b/src/ModalServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Inertia\PropsResolver;
 use Inertia\Response;
 use Inertia\ResponseFactory;
 use Tighten\Ziggy\BladeRouteGenerator;
@@ -50,6 +51,19 @@ class ModalServiceProvider extends ServiceProvider
         // class to pass the modal data as a prop to the base URL.
         Response::macro('toArray', function (): array {
             $request = app('request');
+
+            if (Support::isInertiaV3()) {
+                $resolver = new PropsResolver($request, $this->component);
+                [$resolvedProps, $resolvedMetadata] = $resolver->resolve($this->sharedProps ?? [], $this->props);
+
+                return [
+                    'component' => $this->component,
+                    'props' => $resolvedProps,
+                    'version' => $this->version,
+                    'url' => Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/'),
+                    'meta' => $resolvedMetadata,
+                ];
+            }
 
             if (Support::isInertiaV2()) {
                 $props = $this->resolveProperties($request, $this->props);

--- a/src/Support.php
+++ b/src/Support.php
@@ -13,6 +13,11 @@ class Support
 
     public static function isInertiaV2(): bool
     {
-        return class_exists(\Inertia\DeferProp::class);
+        return class_exists(\Inertia\DeferProp::class) && ! static::isInertiaV3();
+    }
+
+    public static function isInertiaV3(): bool
+    {
+        return class_exists(\Inertia\PropsResolver::class);
     }
 }

--- a/vue/package.json
+++ b/vue/package.json
@@ -26,7 +26,7 @@
         "test": "vitest"
     },
     "devDependencies": {
-        "@inertiajs/vue3": "^1.3.0||^2.1.11",
+        "@inertiajs/vue3": "^1.3.0||^2.1.11||^3.0.0-beta",
         "@vitejs/plugin-vue": "^5.2.0",
         "@vitest/coverage-v8": "^4.0.0",
         "@vitest/ui": "^4.0.0",
@@ -47,7 +47,7 @@
         "vue": "^3.4.x"
     },
     "peerDependencies": {
-        "@inertiajs/vue3": "^1.3.0||^2.1.11",
+        "@inertiajs/vue3": "^1.3.0||^2.1.11||^3.0.0-beta",
         "axios": "^1.6.0",
         "vue": "^3.4.x"
     },

--- a/vue/package.json
+++ b/vue/package.json
@@ -47,7 +47,7 @@
         "vue": "^3.4.x"
     },
     "peerDependencies": {
-        "@inertiajs/vue3": "^1.3.0||^2.1.11||^3.0.0-beta",
+        "@inertiajs/vue3": "^1.3.0||^2.1.11||^3.0.0",
         "axios": "^1.6.0",
         "vue": "^3.4.x"
     },

--- a/vue/package.json
+++ b/vue/package.json
@@ -26,7 +26,7 @@
         "test": "vitest"
     },
     "devDependencies": {
-        "@inertiajs/vue3": "^1.3.0||^2.1.11||^3.0.0-beta",
+        "@inertiajs/vue3": "^1.3.0||^2.1.11||^3.0.0",
         "@vitejs/plugin-vue": "^5.2.0",
         "@vitest/coverage-v8": "^4.0.0",
         "@vitest/ui": "^4.0.0",

--- a/vue/src/ModalRoot.vue
+++ b/vue/src/ModalRoot.vue
@@ -37,6 +37,7 @@ onUnmounted(
 
                 if (!isNavigating && typeof window !== 'undefined' && window.location.href !== modalOnBase.baseUrl) {
                     modalStack.setBaseUrl(null)
+                    initialModalStillOpened = false
                     router.visit(modalOnBase.baseUrl, {
                         preserveScroll: true,
                         preserveState: true,

--- a/vue/src/ModalRoot.vue
+++ b/vue/src/ModalRoot.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { onBeforeMount, onMounted, onUnmounted, watch } from 'vue'
 import { router, usePage } from '@inertiajs/vue3'
+import * as InertiaVue from '@inertiajs/vue3'
 import { useModalStack } from './modalStack'
 import ModalRenderer from './ModalRenderer.vue'
 import { default as Axios } from 'axios'
@@ -45,17 +46,32 @@ onUnmounted(
     }),
 )
 
-const axiosRequestInterceptor = (config) => {
+const requestInterceptor = (config) => {
     // A Modal is opened on top of a base route, so we need to pass this base route
     // so it can redirect back with the back() helper method...
-    config.headers['X-InertiaUI-Modal-Base-Url'] = modalStack.getBaseUrl() ?? (initialModalStillOpened ? $page.props._inertiaui_modal?.baseUrl : null)
+    const baseUrlHeader = modalStack.getBaseUrl() ?? (initialModalStillOpened ? $page.props._inertiaui_modal?.baseUrl : null)
+
+    if (config.headers) {
+        config.headers['X-InertiaUI-Modal-Base-Url'] = baseUrlHeader
+    }
 
     return config
 }
 
-onBeforeMount(() => Axios.interceptors.request.use(axiosRequestInterceptor))
+const http = InertiaVue.http && typeof InertiaVue.http.onRequest === 'function' ? InertiaVue.http : null
+let removeHttpInterceptor = null
+
+onBeforeMount(() => {
+    if (http) {
+        removeHttpInterceptor = http.onRequest(requestInterceptor)
+    }
+    Axios.interceptors.request.use(requestInterceptor)
+})
 onMounted(() => (initialModalStillOpened = !!$page.props._inertiaui_modal))
-onUnmounted(() => Axios.interceptors.request.eject(axiosRequestInterceptor))
+onUnmounted(() => {
+    removeHttpInterceptor?.()
+    Axios.interceptors.request.eject(requestInterceptor)
+})
 
 watch(
     () => $page.props?._inertiaui_modal,

--- a/vue/src/ModalRoot.vue
+++ b/vue/src/ModalRoot.vue
@@ -36,6 +36,7 @@ onUnmounted(
                 }
 
                 if (!isNavigating && typeof window !== 'undefined' && window.location.href !== modalOnBase.baseUrl) {
+                    modalStack.setBaseUrl(null)
                     router.visit(modalOnBase.baseUrl, {
                         preserveScroll: true,
                         preserveState: true,
@@ -51,7 +52,7 @@ const requestInterceptor = (config) => {
     // so it can redirect back with the back() helper method...
     const baseUrlHeader = modalStack.getBaseUrl() ?? (initialModalStillOpened ? $page.props._inertiaui_modal?.baseUrl : null)
 
-    if (config.headers) {
+    if (config.headers && baseUrlHeader) {
         config.headers['X-InertiaUI-Modal-Base-Url'] = baseUrlHeader
     }
 


### PR DESCRIPTION
### Summary
Enable compatibility with inertiajs/inertia-laravel v3, which replaced Response::resolveProperties() and related methods with a standalone PropsResolver class.

#### Changes

- [composer.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): Allow inertiajs/inertia-laravel ^3.0.
- Support.php: Add isInertiaV3() detection (via PropsResolver class existence) and update isInertiaV2() to exclude v3.
- ModalServiceProvider.php: When running with Inertia v3, use PropsResolver to resolve props and metadata in the Response::toArray() macro.
- Modal.php: Expand extractMeta() to handle v3 metadata keys (prependProps, deepMergeProps, matchPropsOn, scrollProps, onceProps, sharedProps) while retaining v2 keys.
- DispatchBaseUrlRequest.php: Copy the original request's session onto the subrequest so middleware that depends on the session store doesn't throw a RuntimeException.
- Context
- In inertia-laravel v3, Response::resolveProperties(), resolveMergeProps(), and resolveDeferredProps() were removed. Prop resolution now happens through Inertia\PropsResolver. Without this change, opening a modal throws BadMethodCallException: Method Inertia\Response::resolveProperties does not exist.

The session fix addresses a separate issue where DispatchBaseUrlRequest creates an internal subrequest that lacks the session store, causing [RuntimeException: Session store not set on request](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).