### PR TITLE
[3.x] Fix re-render on closing non-navigate modals

### DIFF
--- a/demo-app/resources/js/Pages/Users.jsx
+++ b/demo-app/resources/js/Pages/Users.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Link, useForm } from '@inertiajs/react';
 import { ModalLink } from '@inertiaui/modal-react';
 import Container from './Container';
@@ -6,6 +6,16 @@ import ComponentThatUsesModalInstance from './ComponentThatUsesModalInstance.jsx
 import * as InertiaReact from '@inertiajs/react';
 
 export default function Users({ users, random, navigate, deferred }) {
+    // Track component re-renders for testing (#204)
+    const isFirstRender = useRef(true);
+    useEffect(() => {
+        if (isFirstRender.current) {
+            isFirstRender.current = false;
+            return;
+        }
+        window.__pageUpdateCount = (window.__pageUpdateCount ?? 0) + 1;
+    });
+
     const alertGreeting = (greeting) => {
         alert(greeting);
     };

--- a/demo-app/resources/js/Pages/Users.vue
+++ b/demo-app/resources/js/Pages/Users.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { Link, useForm } from '@inertiajs/vue3'
 import { ModalLink } from '@inertiaui/modal-vue'
-import { onMounted,ref } from 'vue';
+import { onMounted, onUpdated, ref } from 'vue';
 import * as InertiaVue from '@inertiajs/vue3';
 import ComponentThatUsesModalInstance from './ComponentThatUsesModalInstance.vue';
 import Container from './Container.vue'
@@ -32,6 +32,11 @@ const stateB = ref(rand())
 
 onMounted(() => {
     stateB.value = rand()
+})
+
+// Track component re-renders for testing (#204)
+onUpdated(() => {
+    window.__pageUpdateCount = (window.__pageUpdateCount ?? 0) + 1
 })
 
 function alertGreeting(greeting) {

--- a/demo-app/tests/Browser/NoReRenderOnCloseTest.php
+++ b/demo-app/tests/Browser/NoReRenderOnCloseTest.php
@@ -1,0 +1,21 @@
+<?php
+
+it('does not re-render the background page when closing a modal in non-navigate mode', function () {
+    $user = nthUser(8);
+
+    $page = visit('/users')
+        ->waitForText($user->name)
+        ->click("[data-testid='edit-user-{$user->id}']");
+
+    waitForModal($page);
+
+    // Record the update count after modal is fully open
+    $countBefore = $page->page()->evaluate('window.__pageUpdateCount ?? 0');
+
+    clickModalCloseButton($page);
+    waitUntilMissingModal($page);
+
+    $countAfter = $page->page()->evaluate('window.__pageUpdateCount ?? 0');
+
+    expect($countAfter)->toBe($countBefore);
+});

--- a/react/src/ModalRoot.tsx
+++ b/react/src/ModalRoot.tsx
@@ -260,7 +260,11 @@ export const ModalStackProvider = ({ children }: ModalStackProviderProps) => {
                     // Only suppresses navigate events to this specific URL
                     closingToBaseUrlTarget = savedBaseUrl
 
-                    if (savedBaseUrl && typeof window !== 'undefined') {
+                    // Only call router.push() when the URL actually changed (navigate mode).
+                    // In non-navigate mode (default), the URL never changes and _inertiaui_modal
+                    // is never in page props, so router.push() would be a no-op that triggers
+                    // an unnecessary full component re-render in Inertia v3.
+                    if (savedBaseUrl && typeof window !== 'undefined' && !sameUrlPath(savedBaseUrl, window.location.href)) {
                         router.push({
                             url: savedBaseUrl,
                             preserveScroll: true,

--- a/vue/src/modalStack.ts
+++ b/vue/src/modalStack.ts
@@ -1,5 +1,5 @@
 import { computed, readonly, ref, markRaw, h, nextTick, type Component, type Ref, type ComputedRef } from 'vue'
-import { generateId, except, kebabCase, parseResponseData } from './helpers'
+import { generateId, except, kebabCase, parseResponseData, sameUrlPath } from './helpers'
 import { ResponseCache } from './cache'
 import type { ModalTypeConfig } from './config'
 import { router, usePage, progress, http } from '@inertiajs/vue3'
@@ -293,7 +293,11 @@ export class Modal {
             // Only suppresses navigate events to this specific URL
             closingToBaseUrlTarget = savedBaseUrl
 
-            if (savedBaseUrl && typeof window !== 'undefined') {
+            // Only call router.push() when the URL actually changed (navigate mode).
+            // In non-navigate mode (default), the URL never changes and _inertiaui_modal
+            // is never in page props, so router.push() would be a no-op that triggers
+            // an unnecessary full component re-render in Inertia v3.
+            if (savedBaseUrl && typeof window !== 'undefined' && !sameUrlPath(savedBaseUrl, window.location.href)) {
                 router.push({
                     url: savedBaseUrl,
                     preserveScroll: true,


### PR DESCRIPTION
Fixes #204. 

When closing the last modal in non-navigate mode (the default), `afterLeave()` called `router.push()` to clean up the `_inertiaui_modal` page prop. In non-navigate mode this call was entirely unnecessary since the URL never changed and `_inertiaui_modal` was never placed in page props.