### PR TITLE
[3.x] Fix `HeadlessModal` crash when modal URL is visited directly

### DIFF
--- a/demo-app/resources/js/Pages/StandaloneModal.jsx
+++ b/demo-app/resources/js/Pages/StandaloneModal.jsx
@@ -1,0 +1,9 @@
+import { Modal } from '@inertiaui/modal-react'
+
+export default function StandaloneModal() {
+    return (
+        <Modal>
+            <h1>Hi from standalone modal!</h1>
+        </Modal>
+    )
+}

--- a/demo-app/resources/js/Pages/StandaloneModal.vue
+++ b/demo-app/resources/js/Pages/StandaloneModal.vue
@@ -1,0 +1,9 @@
+<script setup>
+import { Modal } from '@inertiaui/modal-vue'
+</script>
+
+<template>
+    <Modal>
+        <h1>Hi from standalone modal!</h1>
+    </Modal>
+</template>

--- a/demo-app/routes/web.php
+++ b/demo-app/routes/web.php
@@ -163,6 +163,11 @@ Route::post('/test-modal-header-check', function () {
     return back();
 })->name('test-modal-header-check');
 
+// Test for navigate mode: modal route without configured base URL
+// When visited directly (e.g. page refresh), the server has no base URL to fall back to,
+// so it returns the modal component as the Inertia page. HeadlessModal must not crash.
+Route::get('/standalone-modal', fn () => Inertia::modal('StandaloneModal'))->name('standalone-modal');
+
 // General pages
 Route::get('{page}', function ($page) use ($deferred) {
     if (request()->query('slow')) {

--- a/demo-app/tests/Browser/BaseRouteTest.php
+++ b/demo-app/tests/Browser/BaseRouteTest.php
@@ -14,7 +14,8 @@ it('can open a modal with a base route', function () {
     clickModalCloseButton($page);
 
     waitUntilMissingModal($page)
-        ->assertPathIs('/users');
+        ->assertPathIs('/users')
+        ->assertNoJavaScriptErrors();
 });
 
 it('can open a stacked modal on top of a modal with a base route', function () {
@@ -38,5 +39,6 @@ it('can open a stacked modal on top of a modal with a base route', function () {
     );
 
     $page->select('role', $newRole->id)
-        ->assertSelected('role', $newRole->id);
+        ->assertSelected('role', $newRole->id)
+        ->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/CloseOnClickOutsideTest.php
+++ b/demo-app/tests/Browser/CloseOnClickOutsideTest.php
@@ -11,7 +11,8 @@ it('closes the modal when clicking outside by default', function () {
     clickOutsideModal($page);
 
     waitUntilMissingModal($page)
-        ->assertNotPresent('div[data-inertiaui-modal-id]');
+        ->assertNotPresent('div[data-inertiaui-modal-id]')
+        ->assertNoJavaScriptErrors();
 });
 
 it('does not close the modal when clicking outside with closeOnClickOutside=false', function () {
@@ -32,6 +33,8 @@ it('does not close the modal when clicking outside with closeOnClickOutside=fals
     clickModalCloseButton($page);
 
     waitUntilMissingModal($page);
+
+    $page->assertNoJavaScriptErrors();
 });
 
 it('closes the slideover when clicking outside by default', function () {
@@ -45,7 +48,8 @@ it('closes the slideover when clicking outside by default', function () {
     clickOutsideModal($page);
 
     waitUntilMissingModal($page)
-        ->assertNotPresent('div[data-inertiaui-modal-id]');
+        ->assertNotPresent('div[data-inertiaui-modal-id]')
+        ->assertNoJavaScriptErrors();
 });
 
 it('does not close the slideover when clicking outside with closeOnClickOutside=false', function () {
@@ -66,4 +70,6 @@ it('does not close the slideover when clicking outside with closeOnClickOutside=
     clickModalCloseButton($page);
 
     waitUntilMissingModal($page);
+
+    $page->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/ConfigPropsTest.php
+++ b/demo-app/tests/Browser/ConfigPropsTest.php
@@ -16,5 +16,6 @@ it('can set config globally', function (bool $navigate) {
         ->assertAttributeContains('.im-slideover-positioner', 'class', 'justify-start') // Left-aligned
         ->assertAttributeContains('.im-slideover-content', 'class', 'p-8') // Padding classes
         ->assertAttributeContains('.im-slideover-content', 'class', 'bg-red-100') // Panel classes
-        ->assertAttributeContains('.im-slideover-wrapper', 'class', 'lg:max-w-2xl'); // Max width
+        ->assertAttributeContains('.im-slideover-wrapper', 'class', 'lg:max-w-2xl') // Max width
+        ->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/ConfigTest.php
+++ b/demo-app/tests/Browser/ConfigTest.php
@@ -19,5 +19,6 @@ it('passes the props from the modal', function (bool $navigate) {
         ->assertAttributeContains('.im-slideover-positioner', 'class', 'justify-start') // Left-aligned
         ->assertAttributeContains('.im-slideover-content', 'class', 'p-8') // Padding classes
         ->assertAttributeContains('.im-slideover-content', 'class', 'bg-red-100') // Panel classes
-        ->assertAttributeContains('.im-slideover-wrapper', 'class', 'lg:max-w-2xl'); // Max width
+        ->assertAttributeContains('.im-slideover-wrapper', 'class', 'lg:max-w-2xl') // Max width
+        ->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/DeferredOnBaseTest.php
+++ b/demo-app/tests/Browser/DeferredOnBaseTest.php
@@ -22,7 +22,8 @@ it('can perform a partial request on a base url', function (bool $navigate) {
 
     waitUntilMissingModal($page)
         ->assertSeeIn("[data-testid='deferred']", 'Deferred data without Base URL header: page users')
-        ->assertPathIs('/users');
+        ->assertPathIs('/users')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');
 
 it('can perform a partial request on a base url when visiting the modal url directly', function () {
@@ -40,7 +41,8 @@ it('can perform a partial request on a base url when visiting the modal url dire
 
     waitUntilMissingModal($page)
         ->assertSeeIn("[data-testid='deferred']", 'Deferred data without Base URL header: page users')
-        ->assertPathIs('/users');
+        ->assertPathIs('/users')
+        ->assertNoJavaScriptErrors();
 });
 
 it('can perform a partial request on a different base url', function () {
@@ -62,5 +64,6 @@ it('can perform a partial request on a different base url', function () {
 
     waitUntilMissingModal($page)
         ->assertSeeIn("[data-testid='deferred']", 'Deferred data without Base URL header: users.show')
-        ->assertPathIs('/users/'.$user->id);
+        ->assertPathIs('/users/'.$user->id)
+        ->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/EmitTest.php
+++ b/demo-app/tests/Browser/EmitTest.php
@@ -11,5 +11,6 @@ it('can dispatch events back and forth between nested modals', function (bool $n
         ->assertPresent(waitForModalSelector(1))
         ->click('Push message to parent')
         ->assertSeeIn("[data-testid='message']", 'Hello from child')
-        ->assertSeeIn("[data-testid='greeting']", 'Thanks from '.User::first()->name);
+        ->assertSeeIn("[data-testid='greeting']", 'Thanks from '.User::first()->name)
+        ->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/EventsTest.php
+++ b/demo-app/tests/Browser/EventsTest.php
@@ -9,7 +9,8 @@ it('can attach listeners to the modal link', function (bool $navigate) {
     clickModalCloseButton($page);
 
     waitUntilMissingModal($page)
-        ->assertSeeIn("[data-testid='log']", 'start,success,close,after-leave');
+        ->assertSeeIn("[data-testid='log']", 'start,success,close,after-leave')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');
 
 it('can attach listeners to the modal component', function () {
@@ -25,6 +26,8 @@ it('can attach listeners to the modal component', function () {
     clickModalCloseButton($page);
 
     waitUntilMissingModal($page);
+
+    $page->assertNoJavaScriptErrors();
 });
 
 it('can attach a listener for blur', function (bool $navigate) {
@@ -39,5 +42,6 @@ it('can attach a listener for blur', function (bool $navigate) {
     clickModalCloseButton($page, 1);
 
     waitUntilMissingModal($page, 1)
-        ->assertSeeIn("[data-testid='log']", 'start,success,blur,focus');
+        ->assertSeeIn("[data-testid='log']", 'start,success,blur,focus')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/FormTest.php
+++ b/demo-app/tests/Browser/FormTest.php
@@ -13,7 +13,8 @@ it('can submit a form from within the modal and show the validation error', func
         ->press('Save')
         ->assertSeeIn('.im-modal-content', 'The name field must be at least 3 characters.')
         ->assertSeeIn(modalSelector(), 'The name field must be at least 3 characters.')
-        ->assertNotPresent('.im-dialog[data-inertiaui-modal-index="1"]');
+        ->assertNotPresent('.im-dialog[data-inertiaui-modal-index="1"]')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');
 
 it('can submit a form and redirect', function (bool $navigate) {
@@ -34,4 +35,6 @@ it('can submit a form and redirect', function (bool $navigate) {
         'id' => $user->id,
         'name' => $newName,
     ]);
+
+    $page->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/HeaderTest.php
+++ b/demo-app/tests/Browser/HeaderTest.php
@@ -5,5 +5,6 @@ it('can open a modal with a custom header', function (bool $navigate) {
         ->waitForText('Header')
         ->click('Open Modal')
         ->assertPresent(waitForModalSelector())
-        ->assertSeeIn("[data-testid='headerValue']", 'Test Header Value');
+        ->assertSeeIn("[data-testid='headerValue']", 'Test Header Value')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/HistoryTest.php
+++ b/demo-app/tests/Browser/HistoryTest.php
@@ -19,7 +19,8 @@ it('can open a modal and state it in the history', function () {
         ->forward()
         ->assertPresent(waitForModalSelector())
         ->assertSeeIn('.im-modal-content', 'Edit User')
-        ->assertPathIs('/users/'.$user->id.'/edit');
+        ->assertPathIs('/users/'.$user->id.'/edit')
+        ->assertNoJavaScriptErrors();
 });
 
 it('can redirect back to the same base route', function () {
@@ -41,6 +42,8 @@ it('can redirect back to the same base route', function () {
         'id' => $user->id,
         'name' => $newName,
     ]);
+
+    $page->assertNoJavaScriptErrors();
 });
 
 it('can redirect back to a different base route', function () {
@@ -62,4 +65,6 @@ it('can redirect back to a different base route', function () {
         'id' => $user->id,
         'name' => $newName,
     ]);
+
+    $page->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/IgnoreOnFirstLoadTest.php
+++ b/demo-app/tests/Browser/IgnoreOnFirstLoadTest.php
@@ -11,7 +11,8 @@ it('ignores props on first load when opening a modal from a base route', functio
         ->assertSeeIn(modalSelector(), 'No lazy data loaded')
         // Optional props should load after pressing Make visible
         ->press('Make visible')
-        ->assertSeeIn("[data-testid='optional']", 'Optional data');
+        ->assertSeeIn("[data-testid='optional']", 'Optional data')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');
 
 it('can lazily load props', function (bool $navigate) {
@@ -21,7 +22,8 @@ it('can lazily load props', function (bool $navigate) {
         ->assertPresent(waitForModalSelector())
         ->assertSeeIn(modalSelector(), 'No lazy data loaded')
         ->press('Load lazy')
-        ->assertSeeIn("[data-testid='lazy']", 'Lazy data');
+        ->assertSeeIn("[data-testid='lazy']", 'Lazy data')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');
 
 it('ignores props on first load when opening a modal directly', function () {
@@ -33,7 +35,8 @@ it('ignores props on first load when opening a modal directly', function () {
         ->assertSeeIn(modalSelector(), 'No lazy data loaded')
         // Optional props should load after pressing Make visible
         ->press('Make visible')
-        ->assertSeeIn("[data-testid='optional']", 'Optional data');
+        ->assertSeeIn("[data-testid='optional']", 'Optional data')
+        ->assertNoJavaScriptErrors();
 });
 
 it('can lazily load props when opening a modal directly', function () {
@@ -42,5 +45,6 @@ it('can lazily load props when opening a modal directly', function () {
         // Lazy Props
         ->assertSeeIn(modalSelector(), 'No lazy data loaded')
         ->press('Load lazy')
-        ->assertSeeIn("[data-testid='lazy']", 'Lazy data');
+        ->assertSeeIn("[data-testid='lazy']", 'Lazy data')
+        ->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/InvalidModalResponseTest.php
+++ b/demo-app/tests/Browser/InvalidModalResponseTest.php
@@ -27,5 +27,6 @@ it('handles invalid modal response gracefully without crashing', function (bool 
     $page->assertNotPresent(modalSelector());
 
     // The page should be functional - verify we can still see user data
-    $page->assertSee(firstUser()->name);
+    $page->assertSee(firstUser()->name)
+        ->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/LoadingPropTest.php
+++ b/demo-app/tests/Browser/LoadingPropTest.php
@@ -31,5 +31,6 @@ it('indicates when a modal is loading', function (bool $navigate) {
     expect($foundLoading)->toBeTrue('Loading state was never visible');
 
     // After modal opens, loading should be done
-    $page->assertDontSeeIn("[data-testid='modal-link']", 'Loading...');
+    $page->assertDontSeeIn("[data-testid='modal-link']", 'Loading...')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/LocalModalTest.php
+++ b/demo-app/tests/Browser/LocalModalTest.php
@@ -10,6 +10,8 @@ it('can open a local modal and a nested one', function () {
     clickModalCloseButton($page, 1);
 
     waitUntilMissingModal($page, 1);
+
+    $page->assertNoJavaScriptErrors();
 });
 
 it('can close a local modal through a template ref', function () {
@@ -19,4 +21,6 @@ it('can close a local modal through a template ref', function () {
         ->press('Close Modal through Ref');
 
     waitUntilMissingModal($page);
+
+    $page->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/LocalPropsTest.php
+++ b/demo-app/tests/Browser/LocalPropsTest.php
@@ -8,5 +8,6 @@ it('can pass props to a local modal via visitModal', function () {
 
     // Assert the props were passed to the modal
     $page->assertSeeIn("[data-testid='modal-message']", 'Hello from props!')
-        ->assertSeeIn("[data-testid='modal-count']", '42');
+        ->assertSeeIn("[data-testid='modal-count']", '42')
+        ->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/MaxWidthTest.php
+++ b/demo-app/tests/Browser/MaxWidthTest.php
@@ -10,6 +10,8 @@ it('can have a modal with different max widths', function (string $size, int $ex
     $width = $page->script("document.querySelector('body .im-modal-wrapper').offsetWidth");
 
     expect($width)->toBe($expectedWidth);
+
+    $page->assertNoJavaScriptErrors();
 })->with('sizeAndPixels');
 
 it('can have a slideover with different max widths', function (string $size, int $expectedWidth) {
@@ -22,6 +24,8 @@ it('can have a slideover with different max widths', function (string $size, int
     $width = $page->script("document.querySelector('body .im-slideover-wrapper').offsetWidth");
 
     expect($width)->toBe($expectedWidth);
+
+    $page->assertNoJavaScriptErrors();
 })->with('sizeAndPixels');
 
 dataset('sizeAndPixels', [

--- a/demo-app/tests/Browser/MethodTest.php
+++ b/demo-app/tests/Browser/MethodTest.php
@@ -5,5 +5,6 @@ it('can open a modal with a custom method and data', function (bool $navigate) {
         ->waitForText('POST Visit')
         ->click('Open POST Modal')
         ->assertPresent(waitForModalSelector())
-        ->assertSeeIn("[data-testid='message']", 'Hey there!');
+        ->assertSeeIn("[data-testid='message']", 'Hey there!')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/MiddlewareCompatibilityTest.php
+++ b/demo-app/tests/Browser/MiddlewareCompatibilityTest.php
@@ -12,5 +12,6 @@ it('can open modal with custom middleware that expects http response', function 
     clickModalCloseButton($page);
 
     waitUntilMissingModal($page)
-        ->assertNotPresent('div[data-inertiaui-modal-id]');
+        ->assertNotPresent('div[data-inertiaui-modal-id]')
+        ->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/ModalBaseUrlModalTest.php
+++ b/demo-app/tests/Browser/ModalBaseUrlModalTest.php
@@ -19,4 +19,6 @@ it('handles modal with base URL that returns another modal without infinite recu
     // Close the modal
     clickModalCloseButton($page, 0);
     waitUntilMissingModal($page);
+
+    $page->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/ModalLinkPropsTest.php
+++ b/demo-app/tests/Browser/ModalLinkPropsTest.php
@@ -16,5 +16,6 @@ it('passes the props from the modal link', function (bool $navigate) {
         ->assertAttributeContains('.im-slideover-positioner', 'class', 'justify-start') // Left-aligned
         ->assertAttributeContains('.im-slideover-content', 'class', 'p-8') // Padding classes
         ->assertAttributeContains('.im-slideover-content', 'class', 'bg-red-100') // Panel classes
-        ->assertAttributeContains('.im-slideover-wrapper', 'class', 'lg:max-w-2xl'); // Max width
+        ->assertAttributeContains('.im-slideover-wrapper', 'class', 'lg:max-w-2xl') // Max width
+        ->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/ModalTest.php
+++ b/demo-app/tests/Browser/ModalTest.php
@@ -12,7 +12,8 @@ it('can open the modal and close it with the close button', function () {
     clickModalCloseButton($page);
 
     waitUntilMissingModal($page)
-        ->assertNotPresent('div[data-inertiaui-modal-id]');
+        ->assertNotPresent('div[data-inertiaui-modal-id]')
+        ->assertNoJavaScriptErrors();
 });
 
 it('can open the slideover and close it with the close button', function (bool $navigate) {
@@ -27,7 +28,8 @@ it('can open the slideover and close it with the close button', function (bool $
     clickModalCloseButton($page);
 
     waitUntilMissingModal($page)
-        ->assertNotPresent('div[data-inertiaui-modal-id]');
+        ->assertNotPresent('div[data-inertiaui-modal-id]')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');
 
 it('can close the modal by pressing Escape key', function () {
@@ -44,7 +46,8 @@ it('can close the modal by pressing Escape key', function () {
     $page->page()->keyUp('Escape');
 
     waitUntilMissingModal($page)
-        ->assertNotPresent('div[data-inertiaui-modal-id]');
+        ->assertNotPresent('div[data-inertiaui-modal-id]')
+        ->assertNoJavaScriptErrors();
 });
 
 it('can close the modal with a custom button', function () {
@@ -58,7 +61,8 @@ it('can close the modal with a custom button', function () {
         ->press('Cancel');
 
     waitUntilMissingModal($page)
-        ->assertNotPresent('div[data-inertiaui-modal-id]');
+        ->assertNotPresent('div[data-inertiaui-modal-id]')
+        ->assertNoJavaScriptErrors();
 });
 
 it('can refetch the same base modal', function () {
@@ -110,5 +114,6 @@ it('can reload with data and headers', function () {
         ->press('Random Key from Data')
         ->assertSeeIn("[data-testid='randomKey']", 'from-data')
         ->press('Random Key from Header')
-        ->assertSeeIn("[data-testid='randomKey']", 'from-header');
+        ->assertSeeIn("[data-testid='randomKey']", 'from-header')
+        ->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/NavigationTest.php
+++ b/demo-app/tests/Browser/NavigationTest.php
@@ -16,4 +16,6 @@ it('closes the modal on navigation', function () {
         ->assertPathIs('/users/'.$user->id);
 
     waitUntilMissingModal($page);
+
+    $page->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/NestedModalTest.php
+++ b/demo-app/tests/Browser/NestedModalTest.php
@@ -38,6 +38,8 @@ it('maintains body scroll lock when opening nested modals', function (bool $navi
     // Body should no longer have scroll lock
     $overflow = $page->script('window.getComputedStyle(document.body).overflow');
     expect($overflow)->not->toBe('hidden');
+
+    $page->assertNoJavaScriptErrors();
 })->with('navigate');
 
 it('can open a second modal on top of the first one', function (bool $navigate) {
@@ -62,6 +64,8 @@ it('can open a second modal on top of the first one', function (bool $navigate) 
         ->assertDontSee('Edit User');
 
     waitUntilMissingModal($page);
+
+    $page->assertNoJavaScriptErrors();
 })->with('navigate');
 
 it('can refresh props after closing the second modal', function () {
@@ -86,5 +90,6 @@ it('can refresh props after closing the second modal', function () {
     );
 
     $page->select('role', $newRole->id)
-        ->assertSelected('role', $newRole->id);
+        ->assertSelected('role', $newRole->id)
+        ->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/PrefetchTest.php
+++ b/demo-app/tests/Browser/PrefetchTest.php
@@ -9,7 +9,8 @@ it('prefetches on mount and fires callbacks', function () {
 
     // Verify the prefetching and prefetched callbacks were fired
     $page->assertSeeIn("[data-testid='log']", 'mount-prefetching')
-        ->assertSeeIn("[data-testid='log']", 'mount-prefetched');
+        ->assertSeeIn("[data-testid='log']", 'mount-prefetched')
+        ->assertNoJavaScriptErrors();
 });
 
 it('prefetches on hover and fires callbacks', function () {
@@ -29,7 +30,8 @@ it('prefetches on hover and fires callbacks', function () {
     // Click to open the modal - it should use the cached response
     $page->click("[data-testid='prefetch-hover']")
         ->assertPresent(waitForModalSelector())
-        ->assertSeeIn('.im-modal-content', 'Edit User');
+        ->assertSeeIn('.im-modal-content', 'Edit User')
+        ->assertNoJavaScriptErrors();
 });
 
 it('opens modal after clicking prefetch link', function () {
@@ -44,5 +46,6 @@ it('opens modal after clicking prefetch link', function () {
         ->assertSeeIn('.im-modal-content', 'Edit User');
 
     // The click-success callback should have fired
-    $page->assertSeeIn("[data-testid='log']", 'click-success');
+    $page->assertSeeIn("[data-testid='log']", 'click-success')
+        ->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/ProgressBarTest.php
+++ b/demo-app/tests/Browser/ProgressBarTest.php
@@ -6,5 +6,6 @@ it('shows the inertia progress bar', function () {
         ->click('Open Slideover')
         ->assertPresent('#nprogress')
         ->assertPresent(waitForModalSelector())
-        ->assertNotPresent('#nprogress');
+        ->assertNotPresent('#nprogress')
+        ->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/PropNameTest.php
+++ b/demo-app/tests/Browser/PropNameTest.php
@@ -5,5 +5,6 @@ it('can have a backend prop called name', function (bool $navigate) {
         ->waitForText('Header')
         ->click('Open Modal')
         ->assertPresent(waitForModalSelector())
-        ->assertSeeIn("[data-testid='name']", 'Test Name');
+        ->assertSeeIn("[data-testid='name']", 'Test Name')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/RedirectBackTest.php
+++ b/demo-app/tests/Browser/RedirectBackTest.php
@@ -30,7 +30,8 @@ it('does not send stale modal base URL header after modal is closed', function (
     // If fixed, we'll see "OK: No stale modal headers detected"
     $page->click("[data-testid='test-modal-header-check']")
         ->waitForText('OK: No stale modal headers detected')
-        ->assertPathIs('/users');
+        ->assertPathIs('/users')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');
 
 // Test that navigating away also clears the stale header
@@ -60,7 +61,8 @@ it('does not use modal base URL for redirect back after modal is closed and navi
     // This should redirect back to /visit (current page), NOT /users (modal base URL)
     $page->click("[data-testid='test-redirect-back']")
         ->waitForText('Redirect back worked correctly!')
-        ->assertPathIs('/visit');
+        ->assertPathIs('/visit')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');
 
 // Simple test that verifies redirect back works from the same page
@@ -82,5 +84,6 @@ it('redirects back to current page after opening and closing modal', function (b
     // This should redirect back to /users
     $page->click("[data-testid='test-redirect-back']")
         ->waitForText('Redirect back worked correctly!')
-        ->assertPathIs('/users');
+        ->assertPathIs('/users')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/RedirectToModalTest.php
+++ b/demo-app/tests/Browser/RedirectToModalTest.php
@@ -14,7 +14,8 @@ it('can open a page that redirects to a modal', function () {
     clickModalCloseButton($page);
 
     waitUntilMissingModal($page)
-        ->assertPathIs('/visit');
+        ->assertPathIs('/visit')
+        ->assertNoJavaScriptErrors();
 });
 
 it('can submit a form and redirect back to the same modal', function () {
@@ -34,4 +35,6 @@ it('can submit a form and redirect back to the same modal', function () {
         'id' => $user->id,
         'name' => $newName,
     ]);
+
+    $page->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/RouterVisitModalTest.php
+++ b/demo-app/tests/Browser/RouterVisitModalTest.php
@@ -1,0 +1,10 @@
+<?php
+
+// When navigate mode pushes a modal URL and the user refreshes, the server returns
+// the modal component as the Inertia page (no base URL to fall back to).
+// HeadlessModal must handle the missing modalContext gracefully.
+
+it('does not crash when visiting a modal URL directly', function () {
+    visit('/standalone-modal')
+        ->assertNoJavaScriptErrors();
+});

--- a/demo-app/tests/Browser/SessionTest.php
+++ b/demo-app/tests/Browser/SessionTest.php
@@ -20,4 +20,6 @@ it('can submit a form and redirect', function (bool $navigate) {
         'id' => $user->id,
         'name' => $newName,
     ]);
+
+    $page->assertNoJavaScriptErrors();
 })->with('navigate');

--- a/demo-app/tests/Browser/UseModalTest.php
+++ b/demo-app/tests/Browser/UseModalTest.php
@@ -11,4 +11,6 @@ it('can inject the current modal context from a component', function () {
         ->press('Close Modal with index 1');
 
     waitUntilMissingModal($page, 1);
+
+    $page->assertNoJavaScriptErrors();
 });

--- a/demo-app/tests/Browser/VisitTest.php
+++ b/demo-app/tests/Browser/VisitTest.php
@@ -5,7 +5,8 @@ it('can programmatically visit a local modal', function (bool $navigate) {
         ->waitForText('Visit programmatically')
         ->press('Open Local Modal')
         ->assertPresent(waitForModalSelector())
-        ->assertSeeIn('.im-modal-content', 'Hi there!');
+        ->assertSeeIn('.im-modal-content', 'Hi there!')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');
 
 it('can programmatically visit a modal', function (bool $navigate) {
@@ -13,7 +14,8 @@ it('can programmatically visit a modal', function (bool $navigate) {
         ->waitForText('Visit programmatically')
         ->press('Open Route Modal')
         ->assertPresent(waitForModalSelector())
-        ->assertSeeIn('.im-modal-content', 'Hi again!');
+        ->assertSeeIn('.im-modal-content', 'Hi again!')
+        ->assertNoJavaScriptErrors();
 })->with('navigate');
 
 it('can programmatically visit a modal and use browser navigation', function () {
@@ -26,5 +28,6 @@ it('can programmatically visit a modal and use browser navigation', function () 
     clickModalCloseButton($page);
 
     waitUntilMissingModal($page)
-        ->assertPathIs('/visit');
+        ->assertPathIs('/visit')
+        ->assertNoJavaScriptErrors();
 });

--- a/react/src/HeadlessModal.tsx
+++ b/react/src/HeadlessModal.tsx
@@ -138,7 +138,7 @@ const HeadlessModal = forwardRef<HeadlessModalRef, HeadlessModalProps>(
         const previousIsOpenRef = useRef<boolean | undefined>(undefined)
 
         useEffect(() => {
-            if (modalContext !== null) {
+            if (modalContext != null) {
                 if (modalContext.isOpen) {
                     onSuccess?.()
                 } else if (previousIsOpenRef.current === true) {
@@ -153,7 +153,7 @@ const HeadlessModal = forwardRef<HeadlessModalRef, HeadlessModalProps>(
         const [rendered, setRendered] = useState(false)
 
         useEffect(() => {
-            if (rendered && modalContext !== null && modalContext.isOpen) {
+            if (rendered && modalContext != null && modalContext.isOpen) {
                 if (modalContext.onTopOfStack) {
                     onFocus?.()
                 } else {

--- a/vue/src/HeadlessModal.vue
+++ b/vue/src/HeadlessModal.vue
@@ -46,9 +46,9 @@ const props = defineProps({
 })
 
 const modalStack = useModalStack()
-const modalContext = props.name ? ref({}) : inject('modalContext')
+const modalContext = props.name ? ref({}) : inject('modalContext', ref(null))
 const config = computed(() => {
-    const isSlideover = modalContext.value.config?.slideover ?? props.slideover ?? getConfig('type') === 'slideover'
+    const isSlideover = modalContext.value?.config?.slideover ?? props.slideover ?? getConfig('type') === 'slideover'
 
     return {
         slideover: isSlideover,
@@ -59,7 +59,7 @@ const config = computed(() => {
         paddingClasses: props.paddingClasses ?? getConfigByType(isSlideover, 'paddingClasses'),
         panelClasses: props.panelClasses ?? getConfigByType(isSlideover, 'panelClasses'),
         position: props.position ?? getConfigByType(isSlideover, 'position'),
-        ...modalContext.value.config,
+        ...modalContext.value?.config,
     }
 })
 
@@ -87,7 +87,7 @@ onBeforeUnmount(() => unsubscribeEventListeners.value?.())
 const $attrs = useAttrs()
 
 function registerEventListeners() {
-    unsubscribeEventListeners.value = modalContext.value.registerEventListenersFromAttrs($attrs)
+    unsubscribeEventListeners.value = modalContext.value?.registerEventListenersFromAttrs($attrs)
 }
 
 const emits = defineEmits(['modal-event', 'focus', 'blur', 'close', 'success'])
@@ -154,6 +154,7 @@ watch(
 )
 
 const nextIndex = computed(() => {
+    if (!modalContext.value) return undefined
     return modalStack.stack.value.find((m) => m.shouldRender && m.index > modalContext.value.index)?.index
 })
 
@@ -172,7 +173,7 @@ defineOptions({
 
 <template>
     <slot
-        v-if="modalContext.shouldRender"
+        v-if="modalContext?.shouldRender"
         v-bind="modalProps"
         :id="modalContext.id"
         :after-leave="modalContext.afterLeave"


### PR DESCRIPTION
When using `HeadlessModal` and visiting a modal URL directly (not through a `ModalLink` or `visitModal()`), the component would crash because `modalContext` is `undefined` outside of a modal stack.