### PR TITLE
Bump @inertiaui/vanilla to ^1.0.0

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -9,12 +9,12 @@
             "version": "3.0.1",
             "license": "MIT",
             "dependencies": {
-                "@inertiaui/vanilla": "^0.3.0"
+                "@inertiaui/vanilla": "^1.0.0"
             },
             "devDependencies": {
                 "@heroicons/react": "^2.1.4",
                 "@inertiajs/react": "^3.0.0",
-                "@inertiaui/vanilla": "^0.3.0",
+                "@inertiaui/vanilla": "^1.0.0",
                 "@testing-library/react": "^16.0.0",
                 "@types/react": "^19.0.0",
                 "@types/react-dom": "^19.0.0",
@@ -1106,9 +1106,9 @@
             }
         },
         "node_modules/@inertiaui/vanilla": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@inertiaui/vanilla/-/vanilla-0.3.0.tgz",
-            "integrity": "sha512-j2EOtFo6XhDUAylhsdMK/7tGzH522cmhFARReOHmpng6eqY+efSwFtO1v6OniGF42lrDEKJFCIoZUC/3JhvZ9A==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@inertiaui/vanilla/-/vanilla-1.0.0.tgz",
+            "integrity": "sha512-SwWmZQdNOqADDl2/PnNk67vGOPdmcBkuYaDfHQm03IloVy0OObcSmWBlO3IQvOPytrzhoj2nE//vjW6DhFi/Mw==",
             "dev": true,
             "license": "MIT"
         },

--- a/react/package.json
+++ b/react/package.json
@@ -36,7 +36,7 @@
     "devDependencies": {
         "@heroicons/react": "^2.1.4",
         "@inertiajs/react": "^3.0.0",
-        "@inertiaui/vanilla": "^0.3.0",
+        "@inertiaui/vanilla": "^1.0.0",
         "@testing-library/react": "^16.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -57,7 +57,7 @@
         "vitest": "^4.0.0"
     },
     "dependencies": {
-        "@inertiaui/vanilla": "^0.3.0"
+        "@inertiaui/vanilla": "^1.0.0"
     },
     "peerDependencies": {
         "@inertiajs/react": "^3.0.0",

--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -9,11 +9,11 @@
             "version": "3.0.1",
             "license": "MIT",
             "dependencies": {
-                "@inertiaui/vanilla": "^0.3.0"
+                "@inertiaui/vanilla": "^1.0.0"
             },
             "devDependencies": {
                 "@inertiajs/vue3": "^3.0.0",
-                "@inertiaui/vanilla": "^0.3.0",
+                "@inertiaui/vanilla": "^1.0.0",
                 "@typescript-eslint/eslint-plugin": "^8.31.0",
                 "@typescript-eslint/parser": "^8.31.0",
                 "@vitejs/plugin-react": "^5.1.4",
@@ -1084,9 +1084,9 @@
             }
         },
         "node_modules/@inertiaui/vanilla": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@inertiaui/vanilla/-/vanilla-0.3.0.tgz",
-            "integrity": "sha512-j2EOtFo6XhDUAylhsdMK/7tGzH522cmhFARReOHmpng6eqY+efSwFtO1v6OniGF42lrDEKJFCIoZUC/3JhvZ9A==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@inertiaui/vanilla/-/vanilla-1.0.0.tgz",
+            "integrity": "sha512-SwWmZQdNOqADDl2/PnNk67vGOPdmcBkuYaDfHQm03IloVy0OObcSmWBlO3IQvOPytrzhoj2nE//vjW6DhFi/Mw==",
             "dev": true,
             "license": "MIT"
         },

--- a/vue/package.json
+++ b/vue/package.json
@@ -35,7 +35,7 @@
     },
     "devDependencies": {
         "@inertiajs/vue3": "^3.0.0",
-        "@inertiaui/vanilla": "^0.3.0",
+        "@inertiaui/vanilla": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^8.31.0",
         "@typescript-eslint/parser": "^8.31.0",
         "@vitejs/plugin-react": "^5.1.4",
@@ -57,7 +57,7 @@
         "vue-tsc": "^2.2.0"
     },
     "dependencies": {
-        "@inertiaui/vanilla": "^0.3.0"
+        "@inertiaui/vanilla": "^1.0.0"
     },
     "peerDependencies": {
         "@inertiajs/vue3": "^3.0.0",


### PR DESCRIPTION
Bumps the `@inertiaui/vanilla` dependency in both the Vue and React packages from `^0.3.0` to `^1.0.0`.