### PR TITLE
Handle Dialog Click more effectively

### DIFF
--- a/react/src/ModalContent.tsx
+++ b/react/src/ModalContent.tsx
@@ -140,10 +140,17 @@ const ModalContent = ({ modalContext, config, useNativeDialog, isFirstModal, onA
 
     const handleDialogClick = useCallback(
         (event: MouseEvent) => {
-            if (event.target === dialogRef.current) {
-                if (modalContext.onTopOfStack && !config?.closeExplicitly && config?.closeOnClickOutside !== false) {
-                    modalContext.close()
-                }
+            if (!modalContext.onTopOfStack || config?.closeExplicitly || config?.closeOnClickOutside === false) {
+                return
+            }
+
+            const clickTarget = event.target as Node | null
+            if (!clickTarget) return
+
+            // Native dialog clicks can bubble from inner layout containers, so treat any click
+            // outside the actual modal wrapper as an outside click.
+            if (nativeWrapperRef.current && !nativeWrapperRef.current.contains(clickTarget)) {
+                modalContext.close()
             }
         },
         [modalContext, config?.closeExplicitly, config?.closeOnClickOutside],

--- a/react/src/SlideoverContent.tsx
+++ b/react/src/SlideoverContent.tsx
@@ -150,10 +150,17 @@ const SlideoverContent = ({ modalContext, config, useNativeDialog, isFirstModal,
 
     const handleDialogClick = useCallback(
         (event: MouseEvent) => {
-            if (event.target === dialogRef.current) {
-                if (modalContext.onTopOfStack && !config?.closeExplicitly && config?.closeOnClickOutside !== false) {
-                    modalContext.close()
-                }
+            if (!modalContext.onTopOfStack || config?.closeExplicitly || config?.closeOnClickOutside === false) {
+                return
+            }
+
+            const clickTarget = event.target as Node | null
+            if (!clickTarget) return
+
+            // Native dialog clicks can bubble from inner layout containers, so treat any click
+            // outside the actual slideover wrapper as an outside click.
+            if (nativeWrapperRef.current && !nativeWrapperRef.current.contains(clickTarget)) {
+                modalContext.close()
             }
         },
         [modalContext, config?.closeExplicitly, config?.closeOnClickOutside],

--- a/vue/src/ModalContent.vue
+++ b/vue/src/ModalContent.vue
@@ -134,10 +134,15 @@ function handleCancel(event) {
 }
 
 function handleDialogClick(event) {
-    if (event.target === dialogRef.value) {
-        if (props.modalContext.onTopOfStack && !props.config?.closeExplicitly && props.config?.closeOnClickOutside !== false) {
-            props.modalContext.close()
-        }
+    if (!props.modalContext.onTopOfStack || props.config?.closeExplicitly || props.config?.closeOnClickOutside === false) return
+
+    const clickTarget = event.target
+    if (!clickTarget) return
+
+    // Native dialog clicks can bubble from inner layout containers, so treat any click
+    // outside the actual modal wrapper as an outside click.
+    if (nativeWrapperRef.value && !nativeWrapperRef.value.contains(clickTarget)) {
+        props.modalContext.close()
     }
 }
 

--- a/vue/src/SlideoverContent.vue
+++ b/vue/src/SlideoverContent.vue
@@ -139,10 +139,15 @@ function handleCancel(event) {
 }
 
 function handleDialogClick(event) {
-    if (event.target === dialogRef.value) {
-        if (props.modalContext.onTopOfStack && !props.config?.closeExplicitly && props.config?.closeOnClickOutside !== false) {
-            props.modalContext.close()
-        }
+    if (!props.modalContext.onTopOfStack || props.config?.closeExplicitly || props.config?.closeOnClickOutside === false) return
+
+    const clickTarget = event.target
+    if (!clickTarget) return
+
+    // Native dialog clicks can bubble from inner layout containers, so treat any click
+    // outside the actual slideover wrapper as an outside click.
+    if (nativeWrapperRef.value && !nativeWrapperRef.value.contains(clickTarget)) {
+        props.modalContext.close()
     }
 }
 


### PR DESCRIPTION
#207 When using the Native Dialog click to close outside does not work. The click WAS getting caught on the im-modal-positioner and the click event target was not the dialog itself. So this ensures that it is either the dialog, the im-modal-positioner or the im-modal-container that is being clicked before it closes. 

I used AI to apply the changes and have tested locally using the demo app. It works for modal and slideover