### PR TITLE
[3.x] Remove build devDependencies from shipped packages

### DIFF
--- a/.github/workflows/consumer-smoke.yml
+++ b/.github/workflows/consumer-smoke.yml
@@ -1,0 +1,99 @@
+name: Consumer Smoke
+
+# Installs Inertia Modal the way a real customer does (clean vendor/ copy, real
+# npm via file:, no Vite dedupe) and asserts the modal opens via the Inertia
+# router with no duplicate Inertia/Vue/React copy bundled. The demo-app cannot
+# catch this: it links the library through the pnpm workspace from a sibling
+# directory, where resolution and dedupe behave differently than a real install.
+
+on:
+  push:
+    paths:
+      - 'vue/**'
+      - 'react/**'
+      - 'src/**'
+      - '**/package.json'
+      - 'consumer-smoke/**'
+      - '.github/workflows/consumer-smoke.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  consumer-smoke:
+    name: Consumer Smoke (${{ matrix.stack }})
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        stack: [vue, react]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl
+          coverage: none
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v6.0.8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: pnpm
+
+      - name: Build the modal library
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter "@inertiaui/modal-${{ matrix.stack }}" build
+
+      - name: Install smoke-test dependencies
+        run: |
+          cd consumer-smoke
+          npm install --no-audit --no-fund
+          npx playwright install --with-deps chromium
+
+      - name: Scaffold + build the consumer app
+        id: scaffold
+        env:
+          STACK: ${{ matrix.stack }}
+          MODAL_REPO: ${{ github.workspace }}
+          WORK: ${{ runner.temp }}/consumer-smoke
+        run: |
+          bash consumer-smoke/setup.sh | tee "$RUNNER_TEMP/setup.log"
+          echo "consumer=$(tail -1 "$RUNNER_TEMP/setup.log")" >> "$GITHUB_OUTPUT"
+
+      - name: Serve + smoke test
+        run: |
+          CONSUMER="${{ steps.scaffold.outputs.consumer }}"
+          cd "$CONSUMER"
+          php artisan serve --port=8000 > "$RUNNER_TEMP/serve.log" 2>&1 &
+          up=
+          for i in $(seq 1 30); do
+              curl -fsS -o /dev/null "http://127.0.0.1:8000/modal-smoke" && { up=1; break; }
+              sleep 1
+          done
+          if [ -z "$up" ]; then echo "server failed to start:"; cat "$RUNNER_TEMP/serve.log"; exit 1; fi
+          node "$GITHUB_WORKSPACE/consumer-smoke/smoke.mjs" "http://127.0.0.1:8000"
+
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: consumer-smoke-${{ matrix.stack }}
+          path: ${{ runner.temp }}/serve.log

--- a/consumer-smoke/.gitignore
+++ b/consumer-smoke/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/consumer-smoke/package.json
+++ b/consumer-smoke/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "consumer-smoke",
+    "private": true,
+    "type": "module",
+    "description": "Smoke test that mirrors a real customer install (file: + real npm, no dedupe).",
+    "dependencies": {
+        "playwright": "^1.50.0"
+    }
+}

--- a/consumer-smoke/setup.sh
+++ b/consumer-smoke/setup.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Build a throwaway Laravel + Inertia app and install Inertia Modal exactly the
+# way a paying customer does:
+#
+#   * the package is a clean, dist-only copy inside vendor/ (as Composer ships it)
+#   * installed with REAL npm through the file: protocol
+#   * NO Vite `dedupe` anywhere
+#
+# That combination is what surfaces a duplicate Inertia/Vue/React copy in the
+# production bundle. The demo-app can never catch it: it links the library
+# through the pnpm workspace from a sibling directory, where resolution and
+# dedupe behave differently than in a real install.
+#
+# When this script finishes, the consumer app is production-built and ready to
+# serve. Point smoke.mjs at it to assert the modal opens via the Inertia router
+# with only one Inertia copy bundled.
+#
+# Modal 3.x targets Inertia 3.x only, so there is a single Inertia axis here.
+#
+# Usage (all required except NPM/PHP):
+#   STACK=vue|react  MODAL_REPO=<repo>  WORK=<scratch>  [NPM=<npm>]  [PHP=<php>]  setup.sh
+#
+# The consumer app directory is printed on the last line.
+
+set -euo pipefail
+
+STACK="${STACK:?set STACK=vue|react}"
+MODAL_REPO="${MODAL_REPO:?set MODAL_REPO=/path/to/modal}"
+WORK="${WORK:?set WORK=/path/to/scratch}"
+NPM="${NPM:-npm}"          # must be real npm, never a pnpm shim
+PHP="${PHP:-php}"          # e.g. php83 on some runners
+STUBS="$MODAL_REPO/consumer-smoke/stubs"
+
+CONSUMER="$WORK/consumer-$STACK"   # the generated app
+SHIPPED="$WORK/shipped-$STACK"     # the package as Composer would ship it
+
+step() { printf '\n==> %s\n' "$1"; }
+
+rm -rf "$CONSUMER" "$SHIPPED"
+
+# ---------------------------------------------------------------------------
+# 1. Build the package exactly as it ships inside vendor/.
+#
+# `git archive` honors export-ignore, so it yields src + react/ + vue/ +
+# package.json with no demo-app, docs, or tests. The built dist is committed, so
+# it comes along too. A concrete version lets a Composer path repo resolve it.
+# ---------------------------------------------------------------------------
+step "stage the shippable package"
+mkdir -p "$SHIPPED"
+git -C "$MODAL_REPO" archive HEAD | tar -x -C "$SHIPPED"
+# Overlay the freshly built dist so the smoke tests the current source rather
+# than whatever dist happens to be committed.
+cp -R "$MODAL_REPO/$STACK/dist/." "$SHIPPED/$STACK/dist/"
+node -e 'const f=process.argv[1]+"/composer.json",j=require(f);j.version="3.99.0";require("fs").writeFileSync(f,JSON.stringify(j,null,4))' "$SHIPPED"
+
+# ---------------------------------------------------------------------------
+# 2. Scaffold from a pinned starter-kit commit.
+#
+# Pinned commits are deterministic; `laravel new` tracks the latest installer
+# and starter and drifts. Both commits ship Inertia v3, matching Modal 3.x.
+# ---------------------------------------------------------------------------
+case "$STACK" in
+    vue)   STARTER_REPO="laravel/vue-starter-kit";   STARTER_SHA="319c08040eebc360af353b679ba5e466a08f91a4" ;;
+    react) STARTER_REPO="laravel/react-starter-kit"; STARTER_SHA="aba049359ec44a8241e9ff823db44973d438b90b" ;;
+    *) echo "unknown STACK: $STACK" >&2; exit 2 ;;
+esac
+
+step "scaffold $STARTER_REPO @ ${STARTER_SHA:0:7} ($STACK)"
+git clone --quiet "https://github.com/$STARTER_REPO" "$CONSUMER"
+git -C "$CONSUMER" checkout --quiet "$STARTER_SHA"
+
+cd "$CONSUMER"
+cp .env.example .env
+composer install --no-interaction --no-progress --quiet
+"$PHP" artisan key:generate --quiet
+touch database/database.sqlite
+
+# ---------------------------------------------------------------------------
+# 3. Install the modal package the customer way.
+#
+# Composer copies the staged package into vendor/ (symlink:false). Then real npm
+# installs it from vendor/ via file:, pulling only its runtime dependencies. A
+# package that still carried its build devDependencies would drag a second
+# Inertia copy in here and break the production build.
+# ---------------------------------------------------------------------------
+step "install the modal package (composer copy + real-npm file:)"
+composer config repositories.modal "{\"type\":\"path\",\"url\":\"$SHIPPED\",\"options\":{\"symlink\":false}}"
+composer require "inertiaui/modal:3.99.0" -W --no-interaction --no-progress
+
+"$NPM" install --no-audit --no-fund
+"$NPM" install --no-audit --no-fund "vendor/inertiaui/modal/$STACK"
+
+# ---------------------------------------------------------------------------
+# 4. Wire a minimal modal smoke page (stubs live in consumer-smoke/stubs).
+#
+# The JS entry is replaced with a tiny modal-wired bootstrap, two pages are
+# added (base page + modal), the route is appended so the starter's own routes
+# stay intact, and the package source is added to Tailwind's @source list.
+# ---------------------------------------------------------------------------
+step "wire the modal smoke page"
+if [ "$STACK" = "vue" ]; then
+    cp "$STUBS/app-vue.ts" resources/js/app.ts
+    cp "$STUBS/ModalSmoke.vue" resources/js/pages/ModalSmoke.vue
+    cp "$STUBS/Greet.vue" resources/js/pages/Greet.vue
+    perl -0pi -e "s{(\@source '\.\./\.\./storage/framework/views/\*\.php';)}{\$1\n\@source '../../vendor/inertiaui/modal/vue/src/**/*.{js,ts,vue}';}" resources/css/app.css
+else
+    cp "$STUBS/app-react.tsx" resources/js/app.tsx
+    cp "$STUBS/ModalSmoke.tsx" resources/js/pages/ModalSmoke.tsx
+    cp "$STUBS/Greet.tsx" resources/js/pages/Greet.tsx
+    perl -0pi -e "s{(\@source '\.\./views';)}{\$1\n\@source '../../vendor/inertiaui/modal/react/src/**/*.{js,jsx,ts,tsx}';}" resources/css/app.css
+fi
+
+cat "$STUBS/web-append.php" >> routes/web.php
+
+# ---------------------------------------------------------------------------
+# 5. Production build + migrate.
+# ---------------------------------------------------------------------------
+step "production build"
+rm -f public/hot
+"$NPM" run build
+
+step "migrate"
+"$PHP" artisan migrate --force --quiet
+
+step "installed Inertia copies (must be a single version)"
+[ "$STACK" = "vue" ] && INERTIA_PKG="@inertiajs/vue3" || INERTIA_PKG="@inertiajs/react"
+"$NPM" ls "$INERTIA_PKG" || true
+
+echo "$CONSUMER"

--- a/consumer-smoke/smoke.mjs
+++ b/consumer-smoke/smoke.mjs
@@ -1,0 +1,91 @@
+// Consumer-install smoke test.
+//
+// Loads the base page in a real (production-built) consumer app and opens a
+// modal by navigating with the Inertia router (a ModalLink click, no full page
+// reload). A duplicate Inertia/Vue/React copy surfaces as a console error or
+// uncaught exception the moment the modal mounts ("usePage must be used within
+// the Inertia component" on React, "Cannot convert undefined or null to object"
+// on Vue). It also asserts the modal actually rendered and that the open really
+// went through the router, so a silently broken bundle still fails.
+//
+// Usage: node smoke.mjs <base-url>
+//        node smoke.mjs http://127.0.0.1:8000
+
+import { chromium } from 'playwright'
+
+const baseUrl = process.argv[2] ?? process.env.SMOKE_URL
+if (!baseUrl) {
+    console.error('Usage: node smoke.mjs <base-url>')
+    process.exit(2)
+}
+
+const pageUrl = new URL('/modal-smoke', baseUrl).toString()
+const expected = 'Hello from the Inertia Modal smoke test'
+const errors = []
+let modalRequested = false
+
+const browser = await chromium.launch()
+const page = await browser.newPage()
+
+page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`))
+page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+        errors.push(`console.error: ${msg.text()}`)
+    }
+})
+// The modal is fetched by the Inertia router over XHR. Seeing that request go
+// out proves the open was a real client-side navigation to the modal route, not
+// a purely local state toggle.
+page.on('request', (req) => {
+    if (/\/modal-smoke\/greet\b/.test(req.url())) {
+        modalRequested = true
+    }
+})
+
+function fail(message) {
+    console.error(`SMOKE FAIL: ${message}`)
+    if (errors.length) {
+        console.error('Captured browser errors:')
+        for (const e of errors) console.error(`  - ${e}`)
+    }
+}
+
+try {
+    await page.goto(pageUrl, { waitUntil: 'networkidle' })
+    await page.waitForSelector('[data-testid="open-modal"]', { timeout: 10_000 })
+
+    // Tag the live document. An Inertia client-side navigation keeps this flag;
+    // a full page reload wipes it. Lets us prove the modal opened via the router
+    // rather than a hard navigation that would mask a broken SPA setup.
+    await page.evaluate(() => {
+        window.__noReload = true
+    })
+
+    // Open the modal by navigating with the Inertia router (ModalLink click).
+    await page.click('[data-testid="open-modal"]')
+    await page.waitForSelector('[data-testid="modal-message"]', { timeout: 10_000 })
+
+    const message = (await page.textContent('[data-testid="modal-message"]'))?.trim()
+    const survivedReload = await page.evaluate(() => window.__noReload === true)
+
+    if (errors.length) {
+        fail(`${errors.length} browser error(s) detected`)
+        process.exitCode = 1
+    } else if (!survivedReload) {
+        fail('modal opened via a full page reload, not the Inertia router')
+        process.exitCode = 1
+    } else if (!modalRequested) {
+        fail('no XHR to the modal route — the open did not go through the Inertia router')
+        process.exitCode = 1
+    } else if (message !== expected) {
+        fail(`modal content did not render (got: ${JSON.stringify(message)})`)
+        process.exitCode = 1
+    } else {
+        console.log('SMOKE PASS: modal opened via the Inertia router, content rendered, no browser errors')
+    }
+} catch (err) {
+    fail(err.message)
+    process.exitCode = 1
+} finally {
+    await browser.close()
+}

--- a/consumer-smoke/stubs/Greet.tsx
+++ b/consumer-smoke/stubs/Greet.tsx
@@ -1,0 +1,17 @@
+import { useModal } from '@inertiaui/modal-react'
+
+// Modal content. useModal() reads the modal/Inertia context, so it throws
+// ("usePage must be used within the Inertia component") the moment a second,
+// uninitialized Inertia copy is bundled.
+export default function Greet({ message }: { message: string }) {
+    const modal = useModal()
+
+    return (
+        <div data-testid="modal-greet" style={{ padding: 24 }}>
+            <p data-testid="modal-message">{message}</p>
+            <button type="button" data-testid="close-modal" onClick={() => modal.close()}>
+                Close
+            </button>
+        </div>
+    )
+}

--- a/consumer-smoke/stubs/Greet.vue
+++ b/consumer-smoke/stubs/Greet.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { useModal } from '@inertiaui/modal-vue'
+
+defineProps<{ message: string }>()
+
+// useModal() reads the modal/Inertia context, so it throws
+// ("Cannot convert undefined or null to object") the moment a second,
+// uninitialized Inertia copy is bundled.
+const modal = useModal()
+</script>
+
+<template>
+    <div data-testid="modal-greet" style="padding: 24px">
+        <p data-testid="modal-message">{{ message }}</p>
+        <button type="button" data-testid="close-modal" @click="modal.close()">Close</button>
+    </div>
+</template>

--- a/consumer-smoke/stubs/ModalSmoke.tsx
+++ b/consumer-smoke/stubs/ModalSmoke.tsx
@@ -1,0 +1,14 @@
+import { ModalLink } from '@inertiaui/modal-react'
+
+// Base page. The ModalLink opens the modal through the Inertia router (no full
+// page reload), which is exactly when a duplicate Inertia copy blows up.
+export default function ModalSmoke() {
+    return (
+        <div style={{ padding: 24 }}>
+            <h1>Modal smoke</h1>
+            <ModalLink href="/modal-smoke/greet" data-testid="open-modal">
+                Open modal
+            </ModalLink>
+        </div>
+    )
+}

--- a/consumer-smoke/stubs/ModalSmoke.vue
+++ b/consumer-smoke/stubs/ModalSmoke.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { ModalLink } from '@inertiaui/modal-vue'
+</script>
+
+<!-- Base page. The ModalLink opens the modal through the Inertia router (no full
+     page reload), which is exactly when a duplicate Inertia copy blows up. -->
+<template>
+    <div style="padding: 24px">
+        <h1>Modal smoke</h1>
+        <ModalLink href="/modal-smoke/greet" data-testid="open-modal">Open modal</ModalLink>
+    </div>
+</template>

--- a/consumer-smoke/stubs/app-react.tsx
+++ b/consumer-smoke/stubs/app-react.tsx
@@ -1,0 +1,28 @@
+// Minimal Inertia + Inertia Modal bootstrap for the consumer smoke test.
+//
+// Deliberately tiny: the duplicate-Inertia bug is about how the package and its
+// peers resolve and bundle in a real customer install, not about the starter's
+// own UI. This mirrors the documented setup: ModalStackProvider wraps the app
+// (via withApp), and ModalRoot is rendered inside the Inertia context through a
+// persistent layout so its usePage() call resolves.
+import '../css/app.css'
+import { createInertiaApp } from '@inertiajs/react'
+import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers'
+import { ModalStackProvider, ModalRoot } from '@inertiaui/modal-react'
+
+function ModalLayout({ children }) {
+    return (
+        <>
+            {children}
+            <ModalRoot />
+        </>
+    )
+}
+
+createInertiaApp({
+    resolve: (name) => resolvePageComponent(`./pages/${name}.tsx`, import.meta.glob('./pages/**/*.tsx')),
+    withApp(app) {
+        return <ModalStackProvider>{app}</ModalStackProvider>
+    },
+    layout: () => ModalLayout,
+})

--- a/consumer-smoke/stubs/app-vue.ts
+++ b/consumer-smoke/stubs/app-vue.ts
@@ -1,0 +1,21 @@
+// Minimal Inertia + Inertia Modal bootstrap for the consumer smoke test.
+//
+// Deliberately tiny: the duplicate-Inertia bug is about how the package and its
+// peers resolve and bundle in a real customer install, not about the starter's
+// own UI. withInertiaModal() wraps the root render with ModalRoot the same way
+// the documented setup does, which is all that is needed to reproduce it.
+import '../css/app.css'
+import { createInertiaApp } from '@inertiajs/vue3'
+import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers'
+import { createApp, h } from 'vue'
+import { withInertiaModal } from '@inertiaui/modal-vue'
+
+createInertiaApp({
+    resolve: (name) => resolvePageComponent(`./pages/${name}.vue`, import.meta.glob('./pages/**/*.vue')),
+    setup({ el, App, props, plugin }) {
+        const app = createApp({ render: () => h(App, props) })
+        app.use(plugin)
+        withInertiaModal(app)
+        app.mount(el)
+    },
+})

--- a/consumer-smoke/stubs/web-append.php
+++ b/consumer-smoke/stubs/web-append.php
@@ -1,0 +1,10 @@
+
+use Inertia\Inertia;
+
+// Base page with the ModalLink, and the modal route it opens. baseRoute() ties
+// the modal back to the base page so closing returns there.
+Route::get('modal-smoke', fn () => Inertia::render('ModalSmoke'))->name('modal-smoke');
+
+Route::get('modal-smoke/greet', fn () => Inertia::modal('Greet', [
+    'message' => 'Hello from the Inertia Modal smoke test',
+])->baseRoute('modal-smoke'))->name('modal-smoke.greet');

--- a/package.json
+++ b/package.json
@@ -13,7 +13,35 @@
         "format": "pnpm --filter @inertiaui/modal-vue prettier && pnpm --filter @inertiaui/modal-react prettier"
     },
     "devDependencies": {
+        "@heroicons/react": "^2.1.4",
         "@inertiajs/core": "^3.0.0",
-        "@inertiaui/vanilla": "^1.0.2"
+        "@inertiajs/react": "^3.0.0",
+        "@inertiajs/vue3": "^3.0.0",
+        "@inertiaui/vanilla": "^1.0.2",
+        "@testing-library/react": "^16.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.31.0",
+        "@typescript-eslint/parser": "^8.31.0",
+        "@vitejs/plugin-react": "^6.0.0",
+        "@vitejs/plugin-vue": "^6.0.4",
+        "@vitest/coverage-v8": "^4.0.0",
+        "@vitest/ui": "^4.0.0",
+        "@vue/test-utils": "^2.4.6",
+        "clsx": "^2.1.1",
+        "eslint": "^9.26.0",
+        "eslint-plugin-vue": "^10.2.0",
+        "happy-dom": "^20.0.0",
+        "laravel-vite-plugin": "^3.0.0",
+        "prettier": "^3.2.4",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "typescript": "^5.7.0",
+        "vite": "^8.0.0",
+        "vite-plugin-dts": "^5.0.0",
+        "vitest": "^4.0.0",
+        "vue": "^3.4.x",
+        "vue-eslint-parser": "^10.1.0",
+        "vue-tsc": "^2.2.0"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,96 @@ importers:
 
   .:
     devDependencies:
+      '@heroicons/react':
+        specifier: ^2.1.4
+        version: 2.2.0(react@19.0.0)
       '@inertiajs/core':
         specifier: ^3.0.0
         version: 3.1.1
+      '@inertiajs/react':
+        specifier: ^3.0.0
+        version: 3.1.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@inertiajs/vue3':
+        specifier: ^3.0.0
+        version: 3.1.1(vue@3.5.34(typescript@5.9.3))
       '@inertiaui/vanilla':
         specifier: ^1.0.2
         version: 1.0.2
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.31.0
+        version: 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.31.0
+        version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.0
+        version: 6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.4
+        version: 6.0.7(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))(vue@3.5.34(typescript@5.9.3))
+      '@vitest/coverage-v8':
+        specifier: ^4.0.0
+        version: 4.1.6(vitest@4.1.6)
+      '@vitest/ui':
+        specifier: ^4.0.0
+        version: 4.1.6(vitest@4.1.6)
+      '@vue/test-utils':
+        specifier: ^2.4.6
+        version: 2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      eslint:
+        specifier: ^9.26.0
+        version: 9.39.4(jiti@2.7.0)
+      eslint-plugin-vue:
+        specifier: ^10.2.0
+        version: 10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.7.0)))
+      happy-dom:
+        specifier: ^20.0.0
+        version: 20.9.0
+      laravel-vite-plugin:
+        specifier: ^3.0.0
+        version: 3.1.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))
+      prettier:
+        specifier: ^3.2.4
+        version: 3.8.3
+      react:
+        specifier: ^19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.0.0(react@19.0.0)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0)
+      vite-plugin-dts:
+        specifier: ^5.0.0
+        version: 5.0.0(@microsoft/api-extractor@7.58.7(@types/node@25.8.0))(esbuild@0.27.7)(rolldown@1.0.1)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.9.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))
+      vue:
+        specifier: ^3.4.x
+        version: 3.5.34(typescript@5.9.3)
+      vue-eslint-parser:
+        specifier: ^10.1.0
+        version: 10.4.0(eslint@9.39.4(jiti@2.7.0))
+      vue-tsc:
+        specifier: ^2.2.0
+        version: 2.2.12(typescript@5.9.3)
 
   demo-app:
     dependencies:
@@ -78,137 +162,30 @@ importers:
 
   react:
     dependencies:
-      '@inertiaui/vanilla':
-        specifier: ^1.0.2
-        version: 1.0.2
-    devDependencies:
-      '@heroicons/react':
-        specifier: ^2.1.4
-        version: 2.2.0(react@19.0.0)
       '@inertiajs/react':
         specifier: ^3.0.0
         version: 3.1.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@testing-library/react':
-        specifier: ^16.0.0
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@types/react':
-        specifier: ^19.0.0
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: ^19.0.0
-        version: 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.0.0
-        version: 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser':
-        specifier: ^8.0.0
-        version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@vitejs/plugin-react':
-        specifier: ^6.0.0
-        version: 6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))
-      '@vitest/coverage-v8':
-        specifier: ^4.0.0
-        version: 4.1.6(vitest@4.1.6)
-      '@vitest/ui':
-        specifier: ^4.0.0
-        version: 4.1.6(vitest@4.1.6)
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
-      eslint:
-        specifier: ^9.0.0
-        version: 9.39.4(jiti@2.7.0)
-      happy-dom:
-        specifier: ^20.0.0
-        version: 20.9.0
-      prettier:
-        specifier: ^3.2.4
-        version: 3.8.3
+      '@inertiaui/vanilla':
+        specifier: ^1.0.2
+        version: 1.0.2
       react:
         specifier: ^19.0.0
         version: 19.0.0
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
-      typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
-      vite:
-        specifier: ^8.0.0
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0)
-      vite-plugin-dts:
-        specifier: ^5.0.0
-        version: 5.0.0(@microsoft/api-extractor@7.58.7(@types/node@25.8.0))(esbuild@0.27.7)(rolldown@1.0.1)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))
-      vitest:
-        specifier: ^4.0.0
-        version: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.9.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))
 
   vue:
     dependencies:
-      '@inertiaui/vanilla':
-        specifier: ^1.0.2
-        version: 1.0.2
-    devDependencies:
       '@inertiajs/vue3':
         specifier: ^3.0.0
         version: 3.1.1(vue@3.5.34(typescript@5.9.3))
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.31.0
-        version: 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser':
-        specifier: ^8.31.0
-        version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@vitejs/plugin-react':
-        specifier: ^6.0.0
-        version: 6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))
-      '@vitejs/plugin-vue':
-        specifier: ^6.0.4
-        version: 6.0.7(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))(vue@3.5.34(typescript@5.9.3))
-      '@vitest/coverage-v8':
-        specifier: ^4.0.0
-        version: 4.1.6(vitest@4.1.6)
-      '@vitest/ui':
-        specifier: ^4.0.0
-        version: 4.1.6(vitest@4.1.6)
-      '@vue/test-utils':
-        specifier: ^2.4.6
-        version: 2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
-      eslint:
-        specifier: ^9.26.0
-        version: 9.39.4(jiti@2.7.0)
-      eslint-plugin-vue:
-        specifier: ^10.2.0
-        version: 10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.7.0)))
-      happy-dom:
-        specifier: ^20.0.0
-        version: 20.9.0
-      laravel-vite-plugin:
-        specifier: ^3.0.0
-        version: 3.1.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))
-      prettier:
-        specifier: ^3.2.4
-        version: 3.8.3
-      typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
-      vite:
-        specifier: ^8.0.0
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0)
-      vite-plugin-dts:
-        specifier: ^5.0.0
-        version: 5.0.0(@microsoft/api-extractor@7.58.7(@types/node@25.8.0))(esbuild@0.27.7)(rolldown@1.0.1)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))
-      vitest:
-        specifier: ^4.0.0
-        version: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(happy-dom@20.9.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0))
+      '@inertiaui/vanilla':
+        specifier: ^1.0.2
+        version: 1.0.2
       vue:
         specifier: ^3.4.x
         version: 3.5.34(typescript@5.9.3)
-      vue-eslint-parser:
-        specifier: ^10.1.0
-        version: 10.4.0(eslint@9.39.4(jiti@2.7.0))
-      vue-tsc:
-        specifier: ^2.2.0
-        version: 2.2.12(typescript@5.9.3)
 
 packages:
 

--- a/react/package.json
+++ b/react/package.json
@@ -33,29 +33,6 @@
         "prettier": "prettier -w src/",
         "test": "vitest"
     },
-    "devDependencies": {
-        "@heroicons/react": "^2.1.4",
-        "@inertiajs/react": "^3.0.0",
-        "@inertiaui/vanilla": "^1.0.2",
-        "@testing-library/react": "^16.0.0",
-        "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0",
-        "@typescript-eslint/eslint-plugin": "^8.0.0",
-        "@typescript-eslint/parser": "^8.0.0",
-        "@vitejs/plugin-react": "^6.0.0",
-        "@vitest/coverage-v8": "^4.0.0",
-        "@vitest/ui": "^4.0.0",
-        "clsx": "^2.1.1",
-        "eslint": "^9.0.0",
-        "happy-dom": "^20.0.0",
-        "prettier": "^3.2.4",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "typescript": "^5.7.0",
-        "vite": "^8.0.0",
-        "vite-plugin-dts": "^5.0.0",
-        "vitest": "^4.0.0"
-    },
     "dependencies": {
         "@inertiaui/vanilla": "^1.0.2"
     },

--- a/vue/package.json
+++ b/vue/package.json
@@ -33,29 +33,6 @@
         "prettier": "prettier -w src/",
         "test": "vitest"
     },
-    "devDependencies": {
-        "@inertiajs/vue3": "^3.0.0",
-        "@inertiaui/vanilla": "^1.0.2",
-        "@typescript-eslint/eslint-plugin": "^8.31.0",
-        "@typescript-eslint/parser": "^8.31.0",
-        "@vitejs/plugin-react": "^6.0.0",
-        "@vitejs/plugin-vue": "^6.0.4",
-        "@vitest/coverage-v8": "^4.0.0",
-        "@vitest/ui": "^4.0.0",
-        "@vue/test-utils": "^2.4.6",
-        "eslint": "^9.26.0",
-        "eslint-plugin-vue": "^10.2.0",
-        "happy-dom": "^20.0.0",
-        "laravel-vite-plugin": "^3.0.0",
-        "prettier": "^3.2.4",
-        "typescript": "^5.7.0",
-        "vite": "^8.0.0",
-        "vite-plugin-dts": "^5.0.0",
-        "vitest": "^4.0.0",
-        "vue": "^3.4.x",
-        "vue-eslint-parser": "^10.1.0",
-        "vue-tsc": "^2.2.0"
-    },
     "dependencies": {
         "@inertiaui/vanilla": "^1.0.2"
     },


### PR DESCRIPTION
Port of inertiaui/table#354. Same fix, same lesson learned there.

Installing via `file:` pulls a package's devDependencies. The shipped Vue/React packages kept their whole build toolchain there, so a consumer install can bundle a second Inertia copy (breaks the build) and drags in deps it doesn't need. The prebuilt packages need none of it, so the devDependencies move to the workspace root.

Adds a `consumer-smoke` CI job that installs the package the way a customer does (clean `vendor/` copy, real npm `file:`, no Vite dedupe) and asserts a modal opens via the Inertia router with a single Inertia copy bundled.

Fixes #183