### PR TITLE
Re-bind matched base route to the current container (Octane + route:cache)

### DIFF
--- a/src/DispatchBaseUrlRequest.php
+++ b/src/DispatchBaseUrlRequest.php
@@ -38,6 +38,12 @@ class DispatchBaseUrlRequest
         $requestForBaseUrl->setDefaultRequestLocale($originalRequest->getDefaultLocale());
 
         $route = $this->router->getRoutes()->match($requestForBaseUrl);
+
+        // Re-bind the route to the current container, like Router::findRoute() does. With
+        // route:cache, CompiledRouteCollection caches the hydrated Route per worker, so under
+        // Octane it may still hold a previous request's (terminated) application sandbox.
+        $route->setContainer(app());
+
         $requestForBaseUrl->setRouteResolver(fn () => $route);
 
         // No need to call setLaravelSession() as it's done by the StartSession middleware


### PR DESCRIPTION
Fixes #247.

`DispatchBaseUrlRequest::__invoke()` matches the base route directly against the route collection but never re-binds it to the current container — unlike Laravel's own dispatch path, where `Router::findRoute()` always calls `$route->setContainer($this->container)` after matching.

Under **Octane + `route:cache`** this matters: `CompiledRouteCollection::getByName()` caches the hydrated `Route` instance per worker, and Octane's `GiveNewApplicationInstanceToRouter` listener only re-binds routes for collections that are `instanceof RouteCollection` (the compiled collection is not). So from the second request per worker onward, `$route->run()` resolves the base controller and its dependencies — including the injected `Request` and its user resolver — from a previous request's terminated sandbox: `$request->user()` returns `null` and query input is stale.

This PR mirrors `Router::findRoute()` by calling `$route->setContainer(app())` right after the match. Outside Octane the container is the same instance, so this is a no-op.

Full mechanism, file references, and repro recipe are in #247.

**On tests:** the suite runs the demo app under `artisan serve`, where each request gets a fresh container, so the bug can't be reproduced in this harness — it requires Octane-style worker reuse plus a compiled route collection. We've validated the equivalent fix in production as an app-level middleware, with an app-side regression test that simulates the stale-container dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
