### PR TITLE
fix: ignore cross-origin referer when resolving modal base URL

### DIFF
--- a/demo-app/tests/Feature/ResolveBaseUrlTest.php
+++ b/demo-app/tests/Feature/ResolveBaseUrlTest.php
@@ -215,6 +215,17 @@ class ResolveBaseUrlTest extends TestCase
     }
 
     #[Test]
+    public function it_ignores_cross_origin_referer_when_resolving_base_url()
+    {
+        $this->modal->baseUrl('https://example.com/users');
+
+        $request = Request::create('https://example.com/users/1/edit', 'GET');
+        $request->headers->set('referer', 'https://www.google.com/search?q=foo');
+
+        $this->assertEquals('https://example.com/users', $this->modal->resolveBaseUrl($request));
+    }
+
+    #[Test]
     public function it_prevents_infinite_loop_when_referer_matches_modal_route()
     {
         $user = UserFactory::new()->create();

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -115,10 +115,12 @@ class Modal implements Responsable
      */
     public function resolveBaseUrl(Request $request): ?string
     {
+        $referer = $request->header('referer');
+
         // Check each source in priority order, skipping any that match current path (prevents infinite loops)
         $candidates = [
             $request->header(self::HEADER_BASE_URL),
-            $request->header('referer'),
+            $this->isAcceptableReferer($request, $referer) ? $referer : null,
             $this->getBaseUrl(),
         ];
 
@@ -129,6 +131,64 @@ class Modal implements Responsable
         }
 
         return null;
+    }
+
+    /**
+     * Determine whether the referer may be used as a base URL candidate.
+     */
+    protected function isAcceptableReferer(Request $request, ?string $referer): bool
+    {
+        if ($referer === null) {
+            return false;
+        }
+
+        $refererOrigin = $this->extractOrigin($referer);
+
+        if ($refererOrigin === null) {
+            return true;
+        }
+
+        if ($refererOrigin === $this->extractOriginFromRequest($request)) {
+            return true;
+        }
+
+        $baseUrl = $this->getBaseUrl();
+
+        return $baseUrl !== null && $refererOrigin === $this->extractOrigin($baseUrl);
+    }
+
+    /**
+     * @return array{scheme: string, host: string, port: int|null}|null
+     */
+    protected function extractOrigin(string $url): ?array
+    {
+        $parts = parse_url($url);
+
+        if ($parts === false || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        return [
+            'scheme' => strtolower($parts['scheme']),
+            'host' => strtolower($parts['host']),
+            'port' => $parts['port'] ?? match (strtolower($parts['scheme'])) {
+                'http' => 80,
+                'https' => 443,
+                default => null,
+            },
+        ];
+    }
+
+    /**
+     * @return array{scheme: string, host: string, port: int|null}
+     */
+    protected function extractOriginFromRequest(Request $request): array
+    {
+        return [
+            'scheme' => strtolower($request->getScheme()),
+            'host' => strtolower($request->getHost()),
+            'port' => $request->getPort(),
+        ];
     }
 
     /**

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -134,7 +134,9 @@ class Modal implements Responsable
     }
 
     /**
-     * Determine whether the referer may be used as a base URL candidate.
+     * Determine whether the referer may be used as a base URL candidate. Relative
+     * referers are always accepted; absolute referers must match the origin of
+     * the current request or the configured base URL.
      */
     protected function isAcceptableReferer(Request $request, ?string $referer): bool
     {
@@ -144,23 +146,16 @@ class Modal implements Responsable
 
         $refererOrigin = $this->extractOrigin($referer);
 
-        if ($refererOrigin === null) {
-            return true;
-        }
-
-        if ($refererOrigin === $this->extractOriginFromRequest($request)) {
-            return true;
-        }
-
-        $baseUrl = $this->getBaseUrl();
-
-        return $baseUrl !== null && $refererOrigin === $this->extractOrigin($baseUrl);
+        return $refererOrigin === null
+            || $refererOrigin === strtolower($request->getSchemeAndHttpHost())
+            || $refererOrigin === $this->extractOrigin((string) $this->getBaseUrl());
     }
 
     /**
-     * @return array{scheme: string, host: string, port: int|null}|null
+     * Extract the normalized origin (scheme://host[:port], default ports omitted)
+     * from a URL, or null when the URL has no scheme and host.
      */
-    protected function extractOrigin(string $url): ?array
+    protected function extractOrigin(string $url): ?string
     {
         $parts = parse_url($url);
 
@@ -168,27 +163,14 @@ class Modal implements Responsable
             return null;
         }
 
-        return [
-            'scheme' => strtolower($parts['scheme']),
-            'host' => strtolower($parts['host']),
-            'port' => $parts['port'] ?? match (strtolower($parts['scheme'])) {
-                'http' => 80,
-                'https' => 443,
-                default => null,
-            },
-        ];
-    }
+        $scheme = strtolower($parts['scheme']);
+        $origin = $scheme.'://'.strtolower($parts['host']);
 
-    /**
-     * @return array{scheme: string, host: string, port: int|null}
-     */
-    protected function extractOriginFromRequest(Request $request): array
-    {
-        return [
-            'scheme' => strtolower($request->getScheme()),
-            'host' => strtolower($request->getHost()),
-            'port' => $request->getPort(),
-        ];
+        if (isset($parts['port']) && $parts['port'] !== ($scheme === 'https' ? 443 : 80)) {
+            $origin .= ':'.$parts['port'];
+        }
+
+        return $origin;
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #259

`Modal::resolveBaseUrl()` used the raw `Referer` header as a base URL candidate without validating origin. On a direct visit to a modal URL (no `X-InertiaUI-Modal` header), a cross-origin referer — e.g. from a search engine or external link — was passed to `DispatchBaseUrlRequest`, which tried to route it as an internal background page. This caused a 404 or the wrong page rendered under the modal URL.

This adds an origin check (scheme + host + port) before accepting the referer. Relative referers (no scheme/host) are still accepted.

## Test plan

- [x] Added `it_ignores_cross_origin_referer_when_resolving_base_url` test
- [x] `php artisan test tests/Feature/ResolveBaseUrlTest.php` — 20 passed
- [x] Verified against a Laravel 12 app with host-based routing (multitenant)
