### PR TITLE
Accept Vue's App in withInertiaModal()

### DIFF
--- a/vue/src/modalStack.ts
+++ b/vue/src/modalStack.ts
@@ -1,6 +1,6 @@
 import { mergeDataIntoQueryString, type RequestPayload, type HttpResponse, type Method } from '@inertiajs/core'
 import { router, usePage, progress, http } from '@inertiajs/vue3'
-import { computed, readonly, ref, markRaw, h, nextTick, type Component, type Ref, type ComputedRef } from 'vue'
+import { computed, readonly, ref, markRaw, h, nextTick, type App, type Component, type Ref, type ComputedRef } from 'vue'
 
 import { ResponseCache } from './cache'
 import type { ModalTypeConfig } from './config'
@@ -586,10 +586,13 @@ export const renderApp = (App: Component, props: { resolveComponent?: ComponentR
     return () => h(ModalRoot, () => h(App, props))
 }
 
-export const withInertiaModal = (app: { _component: { render?: () => ReturnType<typeof h> } }): void => {
-    const originalRender = app._component.render
+export const withInertiaModal = (app: App | { _component: { render?: () => ReturnType<typeof h> } }): void => {
+    // A `ConcreteComponent` may be functional and has no typed `render`, but the root component mounted by Inertia always returns a single VNode.
+    const rootComponent = app._component as { render?: () => ReturnType<typeof h> }
+    const originalRender = rootComponent.render
+
     if (originalRender) {
-        app._component.render = () => h(ModalRoot, () => originalRender())
+        rootComponent.render = () => h(ModalRoot, () => originalRender())
     }
 }
 


### PR DESCRIPTION
The parameter only accepted `{ _component: { render?: () => VNode } }`, but `withApp()` hands over Vue's `App`, whose `_component.render` is a plain `Function`. That mismatch made the documented setup impossible to typecheck.

Widened to a union so the old shape still works, and moved the cast inside the function (No runtime change).

<img width="1338" height="366" alt="Screenshot 2026-08-08 at 22 36 50" src="https://github.com/user-attachments/assets/ad18c2ea-f4fe-461e-aced-3cb44fcd1546" />

```
Argument of type 'App<any>' is not assignable to parameter of type '{ _component: { render?: (() => VNode<RendererNode, RendererElement, { [key: string]: any; }>) | undefined; }; }'.
  Types of property '_component' are incompatible.
    Type 'ConcreteComponent<{}, any, any, ComputedOptions, MethodOptions, {}, any>' is not assignable to type '{ render?: (() => VNode<RendererNode, RendererElement, { [key: string]: any; }>) | undefined; }'.
      Value of type 'FunctionalComponent<{}, {}, any, {}>' has no properties in common with type '{ render?: (() => VNode<RendererNode, RendererElement, { [key: string]: any; }>) | undefined; }'. Did you mean to call it?
```